### PR TITLE
Add fault tolerance to log collection

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,9 @@ task :default => :test
 task :test do
   unless system("docker image inspect rspec-runner > /dev/null 2>&1")
     puts "Building RSpec runner Docker image..."
-    system("docker build --build-arg RUBY_VERSION=$DOCKER_RUBY_VERSION -t rspec-runner .")
+
+    ruby_version = ENV.has_key?("DOCKER_RUBY_VERSION") ? ENV["DOCKER_RUBY_VERSION"] : "3.3"
+    system("docker build --build-arg RUBY_VERSION=#{ruby_version} -t rspec-runner .")
   end
 
   additional_options = ENV["debug"] ? "-it" : ""

--- a/lib/scout_apm/logging/config.rb
+++ b/lib/scout_apm/logging/config.rb
@@ -15,6 +15,8 @@ module ScoutApm
         monitor_logs
         monitor_pid_file
         monitor_data_file
+        collector_sending_queue_storage_dir
+        collector_offset_storage_dir
         collector_pid_file
         collector_download_dir
         collector_config_file
@@ -96,8 +98,10 @@ module ScoutApm
           'log_level' => 'info',
           'monitor_pid_file' => '/tmp/scout_apm/scout_apm_log_monitor.pid',
           'monitor_data_file' => '/tmp/scout_apm/scout_apm_log_monitor_data.json',
+          'collector_offset_storage_dir' => '/tmp/scout_apm/file_storage/receiver/',
+          'collector_sending_queue_storage_dir' => '/tmp/scout_apm/file_storage/otc/',
           'collector_pid_file' => '/tmp/scout_apm/scout_apm_otel_collector.pid',
-          'collector_download_dir' => '/tmp/scout_apm',
+          'collector_download_dir' => '/tmp/scout_apm/',
           'collector_config_file' => '/tmp/scout_apm/config.yml',
           'collector_version' => '0.100.0',
           'monitored_logs' => [],

--- a/lib/scout_apm/logging/utils.rb
+++ b/lib/scout_apm/logging/utils.rb
@@ -8,8 +8,9 @@ module ScoutApm
     module Utils
       # Takes a complete file path, and ensures that the directory structure exists.
       def self.ensure_directory_exists(file_path)
-        directory = File.dirname(file_path)
-        FileUtils.mkdir_p(directory) unless File.directory?(directory)
+        file_path = File.dirname(file_path) unless file_path[-1] == '/'
+
+        FileUtils.mkdir_p(file_path) unless File.directory?(file_path)
       end
 
       # TODO: Add support for other platforms


### PR DESCRIPTION
Adds fault tolerance to the collection of logs (file offset tracking and exporting persistent queue) as described by the collector documentation:
https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/examples/fault-tolerant-logs-collection/README.md