### PR TITLE
Fix process liveliness check

### DIFF
--- a/lib/scout_apm/logging/monitor_manager/manager.rb
+++ b/lib/scout_apm/logging/monitor_manager/manager.rb
@@ -64,7 +64,7 @@ module ScoutApm
         process_id = File.read(context.config.value('monitor_pid_file'))
         return false if process_id.empty?
 
-        process_exists = Utils.check_process_livelyness(process_id.to_i, 'scout_apm_logging_monitor')
+        process_exists = Utils.check_process_liveliness(process_id.to_i, 'scout_apm_logging_monitor')
         File.delete(context.config.value('monitor_pid_file')) unless process_exists
 
         process_exists

--- a/lib/scout_apm/logging/utils.rb
+++ b/lib/scout_apm/logging/utils.rb
@@ -30,7 +30,7 @@ module ScoutApm
         end
       end
 
-      def self.check_process_livelyness(pid, name)
+      def self.check_process_liveliness(pid, name)
         # Pipe to cat to prevent truncation of the output
         process_information = `ps -p #{pid} -o pid=,stat=,command= | cat`
         return false if process_information.empty?

--- a/lib/scout_apm/logging/utils.rb
+++ b/lib/scout_apm/logging/utils.rb
@@ -37,10 +37,9 @@ module ScoutApm
 
         process_information_parts = process_information.split(' ')
         process_information_status = process_information_parts[1]
-        process_information_command = process_information_parts[2]
 
         return false if process_information_status == 'Z'
-        return false unless process_information_command.include?(name)
+        return false unless process_information.include?(name)
 
         true
       end

--- a/spec/integration/monitor_manager/single_monitor_spec.rb
+++ b/spec/integration/monitor_manager/single_monitor_spec.rb
@@ -1,13 +1,11 @@
 # This is really meant to simulate multiple processes calling the MonitorManager setup.
-# Trying to create **multiple fake** rails environments is a bit challening 
+# Trying to create **multiple fake** rails environments is a bit challening
 # (such as a rails app and a couple rails runners).
 
 # See: https://github.com/rails/rails/blob/6d126e03dbbf5d30fa97b580f7dee46343537b7b/railties/test/isolation/abstract_unit.rb#L339
 
 # We simulate the ultimate outcome here -- ie Railtie invoking the setup.
 require 'spec_helper'
-
-require 'pry'
 
 describe ScoutApm::Logging do
   it 'Should only create a single monitor daemon if manager is called multiple times' do

--- a/spec/integration/monitor_manager/single_monitor_spec.rb
+++ b/spec/integration/monitor_manager/single_monitor_spec.rb
@@ -20,12 +20,12 @@ describe ScoutApm::Logging do
 
     expect(File.exist?(pid_file)).to be_truthy
     original_pid = File.read(pid_file).to_i
-    expect(ScoutApm::Logging::Utils.check_process_livelyness(original_pid, 'scout_apm_logging_monitor')).to be_truthy
+    expect(ScoutApm::Logging::Utils.check_process_liveliness(original_pid, 'scout_apm_logging_monitor')).to be_truthy
 
     ScoutApm::Logging::MonitorManager.instance.setup!
     expect(File.exist?(pid_file)).to be_truthy
     updated_pid = File.read(pid_file).to_i
     expect(updated_pid).to eq(original_pid)
-    expect(ScoutApm::Logging::Utils.check_process_livelyness(original_pid, 'scout_apm_logging_monitor')).to be_truthy
+    expect(ScoutApm::Logging::Utils.check_process_liveliness(original_pid, 'scout_apm_logging_monitor')).to be_truthy
   end
 end

--- a/spec/integration/monitor_manager/single_monitor_spec.rb
+++ b/spec/integration/monitor_manager/single_monitor_spec.rb
@@ -1,0 +1,31 @@
+# This is really meant to simulate multiple processes calling the MonitorManager setup.
+# Trying to create **multiple fake** rails environments is a bit challening 
+# (such as a rails app and a couple rails runners).
+
+# See: https://github.com/rails/rails/blob/6d126e03dbbf5d30fa97b580f7dee46343537b7b/railties/test/isolation/abstract_unit.rb#L339
+
+# We simulate the ultimate outcome here -- ie Railtie invoking the setup.
+require 'spec_helper'
+
+require 'pry'
+
+describe ScoutApm::Logging do
+  it 'Should only create a single monitor daemon if manager is called multiple times' do
+    ENV['SCOUT_MONITOR_LOGS'] = 'true'
+
+    pid_file = ScoutApm::Logging::MonitorManager.instance.context.config.value('monitor_pid_file')
+    expect(File.exist?(pid_file)).to be_falsey
+
+    ScoutApm::Logging::MonitorManager.instance.setup!
+
+    expect(File.exist?(pid_file)).to be_truthy
+    original_pid = File.read(pid_file).to_i
+    expect(ScoutApm::Logging::Utils.check_process_livelyness(original_pid, 'scout_apm_logging_monitor')).to be_truthy
+
+    ScoutApm::Logging::MonitorManager.instance.setup!
+    expect(File.exist?(pid_file)).to be_truthy
+    updated_pid = File.read(pid_file).to_i
+    expect(updated_pid).to eq(original_pid)
+    expect(ScoutApm::Logging::Utils.check_process_livelyness(original_pid, 'scout_apm_logging_monitor')).to be_truthy
+  end
+end

--- a/spec/integration/rails/lifecycle_spec.rb
+++ b/spec/integration/rails/lifecycle_spec.rb
@@ -16,7 +16,7 @@ describe ScoutApm::Logging do
     pid = File.read(pid_file).to_i
 
     # Check if the process with the stored PID is running
-    expect(ScoutApm::Logging::Utils.check_process_livelyness(pid, 'scout_apm_logging_monitor')).to be_truthy
+    expect(ScoutApm::Logging::Utils.check_process_liveliness(pid, 'scout_apm_logging_monitor')).to be_truthy
 
     # Give the process time to initialize, download the collector, and start it
     wait_for_process_with_timeout!(

--- a/spec/integration/rails/lifecycle_spec.rb
+++ b/spec/integration/rails/lifecycle_spec.rb
@@ -3,9 +3,11 @@ require 'spec_helper'
 describe ScoutApm::Logging do
   it 'checks the Rails lifecycle for creating the daemon and collector processes' do
     ENV['SCOUT_MONITOR_LOGS'] = 'true'
-    make_basic_app
 
     pid_file = ScoutApm::Logging::MonitorManager.instance.context.config.value('monitor_pid_file')
+    expect(File.exist?(pid_file)).to be_falsey
+
+    make_basic_app
 
     # Check if the PID file exists
     expect(File.exist?(pid_file)).to be_truthy
@@ -14,7 +16,7 @@ describe ScoutApm::Logging do
     pid = File.read(pid_file).to_i
 
     # Check if the process with the stored PID is running
-    ScoutApm::Logging::Utils.check_process_livelyness(pid, 'scout_apm_logging_monitor')
+    expect(ScoutApm::Logging::Utils.check_process_livelyness(pid, 'scout_apm_logging_monitor')).to be_truthy
 
     # Give the process time to initialize, download the collector, and start it
     wait_for_process_with_timeout!(


### PR DESCRIPTION
Fixes the check for the process liveliness. The command= output from ps can (and will) be a command with a space in it. Updates the check to be against the entire information returned from ps.

Adds additional test coverage around the area.