### PR TITLE
Disable internal telemetry for collector

### DIFF
--- a/lib/scout_apm/logging/monitor/collector/configuration.rb
+++ b/lib/scout_apm/logging/monitor/collector/configuration.rb
@@ -70,6 +70,9 @@ module ScoutApm
                     - batch
                   exporters:
                     - otlp
+              telemetry:
+                metrics:
+                  level: none
           CONFIG
         end
 


### PR DESCRIPTION
Disables the collector's internal telemetry. This data gets exposed automatically on port :8888, and if this port is currently bound, the collector won't start.

Neither us nor the healthcheck extension rely on this data.