### PR TITLE
Add ability for advanced configuration of the collector

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -35,6 +35,12 @@ Style/Documentation:
 Naming/PredicateName:
   Enabled: false
 
+Metrics/PerceivedComplexity:
+  Enabled: false
+
+Metrics/CyclomaticComplexity:
+  Enabled: false
+
 Style/ClassVars:
   Enabled: false
 

--- a/lib/scout_apm/logging/config.rb
+++ b/lib/scout_apm/logging/config.rb
@@ -25,6 +25,7 @@ module ScoutApm
         logs_reporting_endpoint
         monitor_interval
         delay_first_healthcheck
+        logs_config
       ].freeze
 
       SETTING_COERCIONS = {

--- a/spec/data/logs_config.yml
+++ b/spec/data/logs_config.yml
@@ -1,0 +1,3 @@
+extensions:
+  file_storage/otc:
+    directory: /dev/null

--- a/spec/unit/monitor/collector/configuration_spec.rb
+++ b/spec/unit/monitor/collector/configuration_spec.rb
@@ -7,6 +7,51 @@ require_relative '../../../../lib/scout_apm/logging/monitor/collector/configurat
 describe ScoutApm::Logging::Collector::Configuration do
   it 'creates the correct configuration for the otelcol' do
     context = ScoutApm::Logging::Context.new
+    setup_collector_config!(context)
+
+    expect(File.exist?(context.config.value('collector_config_file'))).to be_truthy
+    config = YAML.load_file(context.config.value('collector_config_file'))
+
+    expect(config['exporters']['otlp']['endpoint']).to eq('https://otlp.telemetryhub.com:4317')
+    expect(config['exporters']['otlp']['headers']['x-telemetryhub-key']).to eq('00001000010000abc')
+    expect(config['receivers']['filelog']['include']).to eq(['/tmp/fake_log_file.log'])
+  end
+
+  it 'merges in a logs config correctly' do
+    ENV['SCOUT_LOGS_CONFIG'] = File.expand_path('../../../data/logs_config.yml', __dir__)
+
+    context = ScoutApm::Logging::Context.new
+    setup_collector_config!(context)
+
+    expect(File.exist?(context.config.value('collector_config_file'))).to be_truthy
+    config = YAML.load_file(context.config.value('collector_config_file'))
+
+    expect(config['exporters']['otlp']['endpoint']).to eq('https://otlp.telemetryhub.com:4317')
+    expect(config['exporters']['otlp']['headers']['x-telemetryhub-key']).to eq('00001000010000abc')
+    expect(config['receivers']['filelog']['include']).to eq(['/tmp/fake_log_file.log'])
+
+    # Verify merge and consistent keys
+    expect(config['extensions']['file_storage/otc']['directory']).to eq('/dev/null')
+    expect(config['extensions']['file_storage/otc']['timeout']).to eq('10s')
+  end
+
+  it 'handles an empty logs config file well' do
+    ENV['SCOUT_LOGS_CONFIG'] = File.expand_path('../../../data/empty_logs_config.yml', __dir__)
+
+    context = ScoutApm::Logging::Context.new
+    setup_collector_config!(context)
+
+    expect(File.exist?(context.config.value('collector_config_file'))).to be_truthy
+    config = YAML.load_file(context.config.value('collector_config_file'))
+
+    expect(config['exporters']['otlp']['endpoint']).to eq('https://otlp.telemetryhub.com:4317')
+    expect(config['exporters']['otlp']['headers']['x-telemetryhub-key']).to eq('00001000010000abc')
+    expect(config['receivers']['filelog']['include']).to eq(['/tmp/fake_log_file.log'])
+  end
+
+  private
+
+  def setup_collector_config!(context)
     conf_file = File.expand_path('../../../data/mock_config.yml', __dir__)
     context.config = ScoutApm::Logging::Config.with_file(context, conf_file)
     context.health_check_port = 1234
@@ -15,12 +60,5 @@ describe ScoutApm::Logging::Collector::Configuration do
 
     collector_config = ScoutApm::Logging::Collector::Configuration.new(context)
     collector_config.setup!
-
-    expect(File.exist?(context.config.value('collector_config_file'))).to be_truthy
-    config = YAML.load_file(context.config.value('collector_config_file'))
-
-    expect(config['exporters']['otlp']['endpoint']).to eq('https://otlp.telemetryhub.com:4317')
-    expect(config['exporters']['otlp']['headers']['x-telemetryhub-key']).to eq('00001000010000abc')
-    expect(config['receivers']['filelog']['include']).to eq(['/tmp/fake_log_file.log'])
   end
 end

--- a/tooling/checksums.rb
+++ b/tooling/checksums.rb
@@ -8,7 +8,6 @@ require 'digest'
 require 'fileutils'
 require 'net/http'
 require 'pp'
-require 'pry'
 
 DOUBLES = [
   'darwin_amd64',


### PR DESCRIPTION
Adds the ability to configure the collector. While not needed for out of the box general logging, it can be useful for advanced configurations -- such as setting up operators.