### PR TITLE
Add configuration state management

### DIFF
--- a/lib/scout_apm/logging/config.rb
+++ b/lib/scout_apm/logging/config.rb
@@ -94,20 +94,22 @@ module ScoutApm
 
       # Dynamically set state based on the application.
       class ConfigDynamic
-        @@values_to_set = {
+        @values_to_set = {
           'health_check_port': nil
         }
 
-        def self.set_value(key, value)
-          @@values_to_set[key] = value
+        class << self
+          def set_value(key, value)
+            @values_to_set[key] = value
+          end
         end
 
         def value(key)
-          @@values_to_set[key]
+          self.class.values_to_set[key]
         end
 
         def has_key?(key)
-          @@values_to_set.key?(key)
+          self.class.values_to_set.key?(key)
         end
 
         def name
@@ -117,6 +119,21 @@ module ScoutApm
 
       # The multi process configuration state.
       class ConfigState
+        @values_to_set = {
+          'monitored_logs': [],
+          'health_check_port': nil
+        }
+
+        class << self
+          def set_value(key, value)
+            @values_to_set[key] = value
+          end
+
+          def get_values_to_set
+            @values_to_set.keys.map(&:to_s)
+          end
+        end
+
         attr_reader :context, :state
 
         def initialize(context)
@@ -130,25 +147,12 @@ module ScoutApm
           set_values_from_state
         end
 
-        @@values_to_set = {
-          'monitored_logs': [],
-          'health_check_port': nil
-        }
-
-        def self.set_value(key, value)
-          @@values_to_set[key] = value
-        end
-
-        def self.get_values_to_set
-          @@values_to_set.keys.map(&:to_s)
-        end
-
         def value(key)
-          @@values_to_set[key]
+          self.class.values_to_set[key]
         end
 
         def has_key?(key)
-          @@values_to_set.key?(key)
+          self.class.values_to_set.key?(key)
         end
 
         def name

--- a/lib/scout_apm/logging/config.rb
+++ b/lib/scout_apm/logging/config.rb
@@ -14,7 +14,7 @@ module ScoutApm
         logging_ingest_key
         monitor_logs
         monitor_pid_file
-        monitor_data_file
+        monitor_state_file
         collector_sending_queue_storage_dir
         collector_offset_storage_dir
         collector_pid_file
@@ -25,6 +25,7 @@ module ScoutApm
         monitored_logs
         logs_reporting_endpoint
         monitor_interval
+        health_check_port
         delay_first_healthcheck
         logs_config
       ].freeze
@@ -33,7 +34,8 @@ module ScoutApm
         'monitor_logs' => BooleanCoercion.new,
         'monitored_logs' => JsonCoercion.new,
         'monitor_interval' => IntegerCoercion.new,
-        'delay_first_healthcheck' => IntegerCoercion.new
+        'delay_first_healthcheck' => IntegerCoercion.new,
+        'health_check_port' => IntegerCoercion.new,
       }.freeze
 
       def self.with_file(context, file_path = nil, config = {})
@@ -44,7 +46,20 @@ module ScoutApm
           ConfigDefaults.new,
           ConfigNull.new
         ]
-        new(context, overlays)
+        instance = new(context, overlays)
+
+        # We need the current settings to determine where the state file is.
+        instance.add_overlay(ConfigState.new(instance), index: 3)
+
+        instance
+      end
+
+      def flush_state!
+        State.flush_to_file!(self)
+      end
+
+      def add_overlay(overlay, index: -1)
+        @overlays.insert(index, overlay)
       end
 
       def value(key)
@@ -71,10 +86,9 @@ module ScoutApm
         end
       end
 
-      # We try and make assumptions about where the Rails log file is located.
       class ConfigDynamic
         @@values_to_set = {
-          'monitored_logs': []
+          'health_check_port': nil,
         }
 
         def self.set_value(key, value)
@@ -94,12 +108,60 @@ module ScoutApm
         end
       end
 
+      class ConfigState
+        attr_reader :config
+
+        def initialize(config)
+          @config=config
+
+          set_values_from_state
+        end
+
+        @@values_to_set = {
+          'monitored_logs': [],
+          'health_check_port': nil,
+        }
+
+        def self.set_value(key, value)
+          @@values_to_set[key] = value
+        end
+
+        def self.get_values_to_set
+          @@values_to_set.keys.map(&:to_s)
+        end
+
+
+        def value(key)
+          @@values_to_set[key]
+        end
+
+        def has_key?(key)
+          @@values_to_set.key?(key)
+        end
+
+        def name
+          'state'
+        end
+
+        private
+
+        def set_values_from_state
+          data = State.load_state_from_file(config)
+
+          return unless data
+
+          data.each do |key, value|
+            self.class.set_value(key, value)
+          end
+        end
+      end
+
       # Defaults in case no config file has been found.
       class ConfigDefaults
         DEFAULTS = {
           'log_level' => 'info',
           'monitor_pid_file' => '/tmp/scout_apm/scout_apm_log_monitor.pid',
-          'monitor_data_file' => '/tmp/scout_apm/scout_apm_log_monitor_data.json',
+          'monitor_state_file' => '/tmp/scout_apm/scout_apm_log_monitor_state.json',
           'collector_offset_storage_dir' => '/tmp/scout_apm/file_storage/receiver/',
           'collector_sending_queue_storage_dir' => '/tmp/scout_apm/file_storage/otc/',
           'collector_pid_file' => '/tmp/scout_apm/scout_apm_otel_collector.pid',

--- a/lib/scout_apm/logging/config.rb
+++ b/lib/scout_apm/logging/config.rb
@@ -35,7 +35,7 @@ module ScoutApm
         'monitored_logs' => JsonCoercion.new,
         'monitor_interval' => IntegerCoercion.new,
         'delay_first_healthcheck' => IntegerCoercion.new,
-        'health_check_port' => IntegerCoercion.new,
+        'health_check_port' => IntegerCoercion.new
       }.freeze
 
       # The bootstrapped, and initial config that we attach to the context. Will be swapped out by
@@ -45,11 +45,10 @@ module ScoutApm
         overlays = [
           ConfigEnvironment.new,
           ConfigDefaults.new,
-          ConfigNull.new,
+          ConfigNull.new
         ]
         new(context, overlays)
       end
-
 
       def self.with_file(context, file_path = nil, config = {})
         overlays = [
@@ -65,7 +64,7 @@ module ScoutApm
 
       # An easy to use accessor for other parts of the codebase.
       def flush_state!
-        state_config = @overlays.find {|overlay| overlay.is_a? ConfigState }
+        state_config = @overlays.find { |overlay| overlay.is_a? ConfigState }
         state_config.flush_state!
       end
 
@@ -93,9 +92,10 @@ module ScoutApm
         end
       end
 
+      # Dynamically set state based on the application.
       class ConfigDynamic
         @@values_to_set = {
-          'health_check_port': nil,
+          'health_check_port': nil
         }
 
         def self.set_value(key, value)
@@ -115,12 +115,12 @@ module ScoutApm
         end
       end
 
+      # The multi process configuration state.
       class ConfigState
-        attr_reader :context
-        attr_reader :state
+        attr_reader :context, :state
 
         def initialize(context)
-          @context=context
+          @context = context
 
           # Note, the config on the context we are passing in here comes from the Config.without_file. We
           # won't be aware of a state file that was defined in a config file, but this would be a very
@@ -132,7 +132,7 @@ module ScoutApm
 
         @@values_to_set = {
           'monitored_logs': [],
-          'health_check_port': nil,
+          'health_check_port': nil
         }
 
         def self.set_value(key, value)
@@ -142,7 +142,6 @@ module ScoutApm
         def self.get_values_to_set
           @@values_to_set.keys.map(&:to_s)
         end
-
 
         def value(key)
           @@values_to_set[key]

--- a/lib/scout_apm/logging/config.rb
+++ b/lib/scout_apm/logging/config.rb
@@ -92,13 +92,15 @@ module ScoutApm
         end
       end
 
-      # Dynamically set state based on the application.
+      # Dynamically set state based on the application configuration.
       class ConfigDynamic
         @values_to_set = {
           'health_check_port': nil
         }
 
         class << self
+          attr_reader :values_to_set
+
           def set_value(key, value)
             @values_to_set[key] = value
           end
@@ -125,6 +127,8 @@ module ScoutApm
         }
 
         class << self
+          attr_reader :values_to_set
+
           def set_value(key, value)
             @values_to_set[key] = value
           end

--- a/lib/scout_apm/logging/context.rb
+++ b/lib/scout_apm/logging/context.rb
@@ -8,10 +8,6 @@ module ScoutApm
       attr_accessor :application_root
       # The environment of the application
       attr_accessor :application_env
-      # The health check port for the collector. This is dynamically derived based on available ports.
-      attr_accessor :health_check_port
-      # Previous derived data for the monitor daemon. For example, the dervied health check port.
-      attr_accessor :stored_data
 
       # Initially start up without attempting to load a configuration file. We
       # need to be able to lookup configuration options like "application_root"
@@ -39,9 +35,6 @@ module ScoutApm
         @config = config
 
         @logger = nil
-
-        # TODO
-        # log_configuration_settings
       end
     end
 

--- a/lib/scout_apm/logging/monitor/collector/configuration.rb
+++ b/lib/scout_apm/logging/monitor/collector/configuration.rb
@@ -116,7 +116,7 @@ module ScoutApm
         end
 
         def health_check_endpoint
-          "localhost:#{context.health_check_port}"
+          "localhost:#{context.config.value('health_check_port')}"
         end
 
         def assumed_config_file_path

--- a/lib/scout_apm/logging/monitor/monitor.rb
+++ b/lib/scout_apm/logging/monitor/monitor.rb
@@ -69,8 +69,8 @@ module ScoutApm
 
       private
 
-      def has_previous_collector_setup? # rubocop:disable Metrics/AbcSize
-        return false unless context.config.value("health_check_port")
+      def has_previous_collector_setup?
+        return false unless context.config.value('health_check_port')
 
         healthy_response = request_health_check_port("http://localhost:#{context.config.value('health_check_port')}/")
 

--- a/lib/scout_apm/logging/monitor/monitor.rb
+++ b/lib/scout_apm/logging/monitor/monitor.rb
@@ -69,8 +69,18 @@ module ScoutApm
 
       private
 
+      def daemonize_process!
+        # Similar to that of Process.daemon, but we want to keep the dir, STDOUT and STDERR.
+        exit if fork
+        Process.setsid
+        exit if fork
+        $stdin.reopen '/dev/null'
+
+        File.write(context.config.value('monitor_pid_file'), Process.pid)
+      end
+
       def has_previous_collector_setup?
-        return false unless context.config.value('health_check_port')
+        return false unless context.config.value('health_check_port') != 0
 
         healthy_response = request_health_check_port("http://localhost:#{context.config.value('health_check_port')}/")
 

--- a/lib/scout_apm/logging/monitor_manager/manager.rb
+++ b/lib/scout_apm/logging/monitor_manager/manager.rb
@@ -134,9 +134,9 @@ module ScoutApm
       end
 
       def remove_data_file
-        return unless File.exist? context.config.value('monitor_data_file')
+        return unless File.exist? context.config.value('monitor_state_file')
 
-        File.delete(context.config.value('monitor_data_file'))
+        File.delete(context.config.value('monitor_state_file'))
       end
 
       # Remove both the monitor and collector processes that we have spawned.

--- a/lib/scout_apm/logging/state.rb
+++ b/lib/scout_apm/logging/state.rb
@@ -4,23 +4,29 @@ module ScoutApm
   module Logging
     # Responsibling for ensuring safe interprocess persitance around configuration state.
     class Config::State
-      def self.load_state_from_file(config)
-        return unless File.exist?(config.value('monitor_state_file'))
+      attr_reader :context
 
-        file_contents = File.read(config.value('monitor_state_file'))
+      def initialize(context)
+        @context = context
+      end
+
+      def load_state_from_file
+        return unless File.exist?(context.config.value('monitor_state_file'))
+
+        file_contents = File.read(context.config.value('monitor_state_file'))
         data = JSON.parse(file_contents)
       end
 
-      def self.flush_to_file!(config)
-        Utils.ensure_directory_exists(config.value('monitor_state_file'))
+      def flush_to_file!
+        Utils.ensure_directory_exists(context.config.value('monitor_state_file'))
 
-        File.open(config.value('monitor_state_file'), (File::RDWR | File::CREAT), 0644) do |file|
+        File.open(context.config.value('monitor_state_file'), (File::RDWR | File::CREAT), 0644) do |file|
           file.flock(File::LOCK_EX)
 
           # TODO: We will need to merge monitored_logs based on the data in the state file, and not
           # what is currently in the config.
           data = Config::ConfigState.get_values_to_set.inject({}) do |memo, key|
-            memo[key] = config.value(key)
+            memo[key] = context.config.value(key)
             memo
           end
 

--- a/lib/scout_apm/logging/state.rb
+++ b/lib/scout_apm/logging/state.rb
@@ -2,38 +2,38 @@
 
 module ScoutApm
   module Logging
-    # Responsibling for ensuring safe interprocess persitance around configuration state.
-    class Config::State
-      attr_reader :context
+    module Config
+      # Responsibling for ensuring safe interprocess persitance around configuration state.
+      class State
+        attr_reader :context
 
-      def initialize(context)
-        @context = context
-      end
+        def initialize(context)
+          @context = context
+        end
 
-      def load_state_from_file
-        return unless File.exist?(context.config.value('monitor_state_file'))
+        def load_state_from_file
+          return unless File.exist?(context.config.value('monitor_state_file'))
 
-        file_contents = File.read(context.config.value('monitor_state_file'))
-        data = JSON.parse(file_contents)
-      end
+          file_contents = File.read(context.config.value('monitor_state_file'))
+          JSON.parse(file_contents)
+        end
 
-      def flush_to_file!
-        Utils.ensure_directory_exists(context.config.value('monitor_state_file'))
+        def flush_to_file! # rubocop:disable Metrics/AbcSize
+          Utils.ensure_directory_exists(context.config.value('monitor_state_file'))
 
-        File.open(context.config.value('monitor_state_file'), (File::RDWR | File::CREAT), 0644) do |file|
-          file.flock(File::LOCK_EX)
+          File.open(context.config.value('monitor_state_file'), (File::RDWR | File::CREAT), 0o644) do |file|
+            file.flock(File::LOCK_EX)
 
-          # TODO: We will need to merge monitored_logs based on the data in the state file, and not
-          # what is currently in the config.
-          data = Config::ConfigState.get_values_to_set.inject({}) do |memo, key|
-            memo[key] = context.config.value(key)
-            memo
+            # TODO: We will need to merge monitored_logs based on the data in the state file, and not
+            # what is currently in the config.
+            data = Config::ConfigState.get_values_to_set.each_with_object({}) do |key, memo|
+              memo[key] = context.config.value(key)
+            end
+
+            file.rewind # Move cursor to beginning of the file
+            file.truncate(0) # Truncate existing content
+            file.write(JSON.pretty_generate(data))
           end
-
-
-          file.rewind # Move cursor to beginning of the file
-          file.truncate(0) # Truncate existing content
-          file.write(JSON.pretty_generate(data))
         end
       end
     end

--- a/lib/scout_apm/logging/state.rb
+++ b/lib/scout_apm/logging/state.rb
@@ -2,38 +2,37 @@
 
 module ScoutApm
   module Logging
-    module Config
-      # Responsibling for ensuring safe interprocess persitance around configuration state.
-      class State
-        attr_reader :context
+    # Responsibling for ensuring safe interprocess persitance around configuration state.
+    class Config::State # rubocop:disable Style/ClassAndModuleChildren
+      attr_reader :context
 
-        def initialize(context)
-          @context = context
-        end
+      def initialize(context)
+        @context = context
+      end
 
-        def load_state_from_file
-          return unless File.exist?(context.config.value('monitor_state_file'))
+      def load_state_from_file
+        return unless File.exist?(context.config.value('monitor_state_file'))
 
-          file_contents = File.read(context.config.value('monitor_state_file'))
-          JSON.parse(file_contents)
-        end
+        file_contents = File.read(context.config.value('monitor_state_file'))
+        JSON.parse(file_contents)
+      end
 
-        def flush_to_file! # rubocop:disable Metrics/AbcSize
-          Utils.ensure_directory_exists(context.config.value('monitor_state_file'))
+      def flush_to_file! # rubocop:disable Metrics/AbcSize
+        Utils.ensure_directory_exists(context.config.value('monitor_state_file'))
 
-          File.open(context.config.value('monitor_state_file'), (File::RDWR | File::CREAT), 0o644) do |file|
-            file.flock(File::LOCK_EX)
+        File.open(context.config.value('monitor_state_file'), (File::RDWR | File::CREAT), 0o644) do |file|
+          file.flock(File::LOCK_EX)
 
-            # TODO: We will need to merge monitored_logs based on the data in the state file, and not
-            # what is currently in the config.
-            data = Config::ConfigState.get_values_to_set.each_with_object({}) do |key, memo|
-              memo[key] = context.config.value(key)
-            end
-
-            file.rewind # Move cursor to beginning of the file
-            file.truncate(0) # Truncate existing content
-            file.write(JSON.pretty_generate(data))
+          # TODO: We will need to merge monitored_logs based on the data in the state file, and not
+          # what is currently in the config.
+          data = Config::ConfigState.get_values_to_set.each_with_object({}) do |key, memo|
+            memo[key] = context.config.value(key)
           end
+
+          file.rewind # Move cursor to beginning of the file
+          file.truncate(0) # Truncate existing content
+          file.write(JSON.pretty_generate(data))
+          file.flock(File::LOCK_UN)
         end
       end
     end

--- a/lib/scout_apm/logging/state.rb
+++ b/lib/scout_apm/logging/state.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module ScoutApm
+  module Logging
+    # Responsibling for ensuring safe interprocess persitance around configuration state.
+    class Config::State
+      def self.load_state_from_file(config)
+        return unless File.exist?(config.value('monitor_state_file'))
+
+        file_contents = File.read(config.value('monitor_state_file'))
+        data = JSON.parse(file_contents)
+      end
+
+      def self.flush_to_file!(config)
+        Utils.ensure_directory_exists(config.value('monitor_state_file'))
+
+        File.open(config.value('monitor_state_file'), (File::RDWR | File::CREAT), 0644) do |file|
+          file.flock(File::LOCK_EX)
+
+          # TODO: We will need to merge monitored_logs based on the data in the state file, and not
+          # what is currently in the config.
+          data = Config::ConfigState.get_values_to_set.inject({}) do |memo, key|
+            memo[key] = config.value(key)
+            memo
+          end
+
+
+          file.rewind # Move cursor to beginning of the file
+          file.truncate(0) # Truncate existing content
+          file.write(JSON.pretty_generate(data))
+        end
+      end
+    end
+  end
+end

--- a/lib/scout_apm_logging.rb
+++ b/lib/scout_apm_logging.rb
@@ -6,6 +6,7 @@ require 'scout_apm/logging/config'
 require 'scout_apm/logging/logger'
 require 'scout_apm/logging/context'
 require 'scout_apm/logging/utils'
+require 'scout_apm/logging/state'
 
 require 'scout_apm/logging/monitor_manager/manager'
 

--- a/spec/data/state_file.json
+++ b/spec/data/state_file.json
@@ -1,0 +1,3 @@
+{
+  "health_check_port": 1234
+}

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -14,7 +14,7 @@ describe ScoutApm::Logging::Config do
   end
 
   it 'loads the state file into the config' do
-    ENV["SCOUT_MONITOR_STATE_FILE"] = File.expand_path('../data/state_file.json', __dir__)
+    ENV['SCOUT_MONITOR_STATE_FILE'] = File.expand_path('../data/state_file.json', __dir__)
 
     context = ScoutApm::Logging::Context.new
     conf_file = File.expand_path('../data/config_test_1.yml', __dir__)

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -12,4 +12,14 @@ describe ScoutApm::Logging::Config do
     expect(conf.value('logging_ingest_key')).to eq('00001000010000abc')
     expect(conf.value('monitored_logs')).to eq(['/tmp/fake_log_file.log'])
   end
+
+  it 'loads the state file into the config' do
+    ENV["SCOUT_MONITOR_STATE_FILE"] = File.expand_path('../data/state_file.json', __dir__)
+
+    context = ScoutApm::Logging::Context.new
+    conf_file = File.expand_path('../data/config_test_1.yml', __dir__)
+    conf = ScoutApm::Logging::Config.with_file(context, conf_file)
+
+    expect(conf.value('health_check_port')).to eq(1234)
+  end
 end

--- a/spec/unit/monitor/collector/configuration_spec.rb
+++ b/spec/unit/monitor/collector/configuration_spec.rb
@@ -52,9 +52,9 @@ describe ScoutApm::Logging::Collector::Configuration do
   private
 
   def setup_collector_config!(context)
+    ENV["SCOUT_MONITOR_STATE_FILE"] = File.expand_path('../../../data/state_file.json', __dir__)
     conf_file = File.expand_path('../../../data/mock_config.yml', __dir__)
     context.config = ScoutApm::Logging::Config.with_file(context, conf_file)
-    context.health_check_port = 1234
 
     ScoutApm::Logging::Utils.ensure_directory_exists(context.config.value('collector_config_file'))
 

--- a/spec/unit/monitor/collector/configuration_spec.rb
+++ b/spec/unit/monitor/collector/configuration_spec.rb
@@ -52,7 +52,7 @@ describe ScoutApm::Logging::Collector::Configuration do
   private
 
   def setup_collector_config!(context)
-    ENV["SCOUT_MONITOR_STATE_FILE"] = File.expand_path('../../../data/state_file.json', __dir__)
+    ENV['SCOUT_MONITOR_STATE_FILE'] = File.expand_path('../../../data/state_file.json', __dir__)
     conf_file = File.expand_path('../../../data/mock_config.yml', __dir__)
     context.config = ScoutApm::Logging::Config.with_file(context, conf_file)
 

--- a/spec/unit/state_spec.rb
+++ b/spec/unit/state_spec.rb
@@ -12,7 +12,7 @@ describe ScoutApm::Logging::Config do
 
     context.config.flush_state!
 
-    data = ScoutApm::Logging::Config::State.load_state_from_file(conf)
+    data = ScoutApm::Logging::Config::State.new(context).load_state_from_file
 
     expect(data['health_check_port']).to eq(context.config.value('health_check_port'))
     expect(data['monitored_logs']).to eq(context.config.value('monitored_logs'))

--- a/spec/unit/state_spec.rb
+++ b/spec/unit/state_spec.rb
@@ -6,7 +6,7 @@ describe ScoutApm::Logging::Config do
     conf_file = File.expand_path('../data/config_test_1.yml', __dir__)
     conf = ScoutApm::Logging::Config.with_file(context, conf_file)
 
-    context.config=conf
+    context.config = conf
 
     ScoutApm::Logging::Config::ConfigDynamic.set_value('health_check_port', 1234)
 
@@ -17,4 +17,4 @@ describe ScoutApm::Logging::Config do
     expect(data['health_check_port']).to eq(context.config.value('health_check_port'))
     expect(data['monitored_logs']).to eq(context.config.value('monitored_logs'))
   end
-end  
+end

--- a/spec/unit/state_spec.rb
+++ b/spec/unit/state_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe ScoutApm::Logging::Config do
+  it 'flushes and loads the state' do
+    context = ScoutApm::Logging::Context.new
+    conf_file = File.expand_path('../data/config_test_1.yml', __dir__)
+    conf = ScoutApm::Logging::Config.with_file(context, conf_file)
+
+    context.config=conf
+
+    ScoutApm::Logging::Config::ConfigDynamic.set_value('health_check_port', 1234)
+
+    context.config.flush_state!
+
+    data = ScoutApm::Logging::Config::State.load_state_from_file(conf)
+
+    expect(data['health_check_port']).to eq(context.config.value('health_check_port'))
+    expect(data['monitored_logs']).to eq(context.config.value('monitored_logs'))
+  end
+end  


### PR DESCRIPTION
Creates a proper interface for multi process state management.

This will be needed for adding monitoring of derived multiple log files, IE different processes using different loggers.

Will also be needed for the proxy logger.