### PR TITLE
Add ability to read log devices

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,7 +15,7 @@ Metrics/BlockLength:
     - "spec/**/*"
 
 Metrics/ClassLength:
-  Max: 130
+  Max: 150
 
 Style/FrozenStringLiteralComment:
   EnforcedStyle: always
@@ -51,7 +51,7 @@ Naming/AccessorMethodName:
   Enabled: false
 
 Metrics/MethodLength:
-  Max: 20
+  Max: 25
 
 Lint/LiteralAsCondition:
   Enabled: false

--- a/Rakefile
+++ b/Rakefile
@@ -1,23 +1,23 @@
 task :default => :test
 
 task :test do
-  unless system("docker image inspect rspec-runner > /dev/null 2>&1")
-    puts "Building RSpec runner Docker image..."
+  ruby_version = ENV.has_key?("DOCKER_RUBY_VERSION") ? ENV["DOCKER_RUBY_VERSION"] : "3.3"
 
-    ruby_version = ENV.has_key?("DOCKER_RUBY_VERSION") ? ENV["DOCKER_RUBY_VERSION"] : "3.3"
-    system("docker build --build-arg RUBY_VERSION=#{ruby_version} -t rspec-runner .")
+  unless system("docker image inspect rspec-runner-#{ruby_version} > /dev/null 2>&1")
+    puts "Building RSpec runner Docker image..."
+    system("docker build --build-arg RUBY_VERSION=#{ruby_version} -t rspec-runner-#{ruby_version} .")
   end
 
   additional_options = ENV["debug"] ? "-it" : ""
 
   if ENV["file"]
     puts "Running RSpec test for #{ENV["file"]}..."
-    system("docker run -v #{Dir.pwd}/lib:/app/lib -v #{Dir.pwd}/spec:/app/spec #{additional_options} --rm rspec-runner bundle exec rspec #{ENV["file"]} 2>&1")
+    system("docker run -v #{Dir.pwd}/lib:/app/lib -v #{Dir.pwd}/spec:/app/spec #{additional_options} --rm rspec-runner-#{ruby_version} bundle exec rspec #{ENV["file"]} 2>&1")
   else
     puts "Running RSpec tests..."
     Dir.glob("spec/**/*_spec.rb") do |spec_file|
       puts "Running #{spec_file}..."
-      system("docker run -v #{Dir.pwd}/lib:/app/lib -v #{Dir.pwd}/spec:/app/spec #{additional_options} --rm rspec-runner bundle exec rspec #{spec_file} 2>&1")
+      system("docker run -v #{Dir.pwd}/lib:/app/lib -v #{Dir.pwd}/spec:/app/spec #{additional_options} --rm rspec-runner-#{ruby_version} bundle exec rspec #{spec_file} 2>&1")
 
       # Exit the task if a test fails
       unless $?.success?
@@ -28,6 +28,8 @@ task :test do
 end
 
 task :access_container do
-  puts "Accessing a new rspec-runner container..."
-  system("docker run -it --rm -v #{Dir.pwd}/lib:/app/lib -v #{Dir.pwd}/spec:/app/spec --entrypoint /bin/bash rspec-runner")
+  puts "Accessing a new rspec-runner-#{ruby_version} container..."
+
+  ruby_version = ENV.has_key?("DOCKER_RUBY_VERSION") ? ENV["DOCKER_RUBY_VERSION"] : "3.3"
+  system("docker run -it --rm -v #{Dir.pwd}/lib:/app/lib -v #{Dir.pwd}/spec:/app/spec --entrypoint /bin/bash rspec-runner-#{ruby_version}")
 end

--- a/lib/scout_apm/logging/config.rb
+++ b/lib/scout_apm/logging/config.rb
@@ -55,17 +55,15 @@ module ScoutApm
           ConfigEnvironment.new,
           ConfigFile.new(context, file_path, config),
           ConfigDynamic.new,
-          ConfigDefaults.new,
           ConfigState.new(context),
+          ConfigDefaults.new,
           ConfigNull.new
         ]
         new(context, overlays)
       end
 
-      # An easy to use accessor for other parts of the codebase.
-      def flush_state!
-        state_config = @overlays.find { |overlay| overlay.is_a? ConfigState }
-        state_config.flush_state!
+      def state
+        @overlays.find { |overlay| overlay.is_a? ConfigState }
       end
 
       def value(key)
@@ -92,7 +90,7 @@ module ScoutApm
         end
       end
 
-      # Dynamically set state based on the application configuration.
+      # Dynamically set state based on the application.
       class ConfigDynamic
         @values_to_set = {
           'health_check_port': nil
@@ -119,7 +117,7 @@ module ScoutApm
         end
       end
 
-      # The multi process configuration state.
+      # State that is persisted and communicated upon by multiple processes.
       class ConfigState
         @values_to_set = {
           'monitored_logs': [],
@@ -165,6 +163,10 @@ module ScoutApm
 
         def flush_state!
           state.flush_to_file!
+        end
+
+        def add_log_locations!(updated_log_locations)
+          state.flush_to_file!(updated_log_locations)
         end
 
         private

--- a/lib/scout_apm/logging/context.rb
+++ b/lib/scout_apm/logging/context.rb
@@ -6,8 +6,6 @@ module ScoutApm
     class Context
       # The root of the application.
       attr_accessor :application_root
-      # The environment of the application
-      attr_accessor :application_env
 
       # Initially start up without attempting to load a configuration file. We
       # need to be able to lookup configuration options like "application_root"

--- a/lib/scout_apm/logging/logger.rb
+++ b/lib/scout_apm/logging/logger.rb
@@ -2,7 +2,7 @@
 
 module ScoutApm
   module Logging
-    # Custom logger for ScoutApm Logging.
+    # Custom internal logger for ScoutApm Logging.
     class Logger < ScoutApm::Logger
       private
 

--- a/lib/scout_apm/logging/loggers/capture.rb
+++ b/lib/scout_apm/logging/loggers/capture.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'logger'
+
+module ScoutApm
+  module Logging
+    module Loggers
+      # Will capture the log destinations from the application's loggers.
+      class Capture
+        attr_reader :context
+
+        def initialize(context)
+          @context = context
+        end
+
+        def capture_log_locations! # rubocop:disable Metrics/AbcSize
+          logger_instances = []
+
+          logger_instances << Rails.logger if defined?(Rails)
+          logger_instances << Sidekiq.logger if defined?(Sidekiq)
+          logger_instances << ObjectSpace.each_object(::ScoutTestLogger).to_a if defined?(::ScoutTestLogger)
+          logger_instances.flatten!
+
+          updated_log_locations = []
+          logger_instances.each do |log_instance|
+            log_devices = get_log_devices(log_instance)
+            log_locations = get_log_location(log_devices)
+
+            log_locations.each do |location|
+              # TODO: Add a proxy logger if we are logging to STDOUT
+              next if location == $stdout
+
+              updated_log_locations << location
+            end
+          end
+
+          context.config.state.add_log_locations!(updated_log_locations)
+        end
+
+        private
+
+        # In Rails 7.1, broadcast logger was added which allows sinking to multiple IO devices.
+        def get_log_devices(log_instance)
+          # https://github.com/rails/rails/blob/main/activesupport/lib/active_support/logger.rb#L20
+          loggers =
+            if defined?(ActiveSupport::BroadcastLogger) && log_instance.is_a?(ActiveSupport::BroadcastLogger)
+              log_instance.broadcasts
+            else
+              [log_instance]
+            end
+
+          loggers.map { |logger| logger.instance_variable_get(:@logdev) }
+        end
+
+        def get_log_location(log_devices)
+          locations = log_devices.map do |logdev|
+            if logdev.respond_to?(:filename)
+              puts logdev.filename
+              logdev.filename
+            elsif logdev.respond_to?(:dev)
+              device = logdev.dev
+              device.respond_to?(:path) ? device.path : device
+            end
+          end
+
+          locations.compact
+        end
+      end
+    end
+  end
+end

--- a/lib/scout_apm/logging/monitor_manager/manager.rb
+++ b/lib/scout_apm/logging/monitor_manager/manager.rb
@@ -67,8 +67,8 @@ module ScoutApm
         Process.spawn("ruby #{gem_directory}/bin/scout_apm_logging_monitor", in: reader)
 
         reader.close
+        # TODO: Add support for Sinatra.
         writer.puts Rails.root if defined?(Rails)
-        writer.puts Rails.env if defined?(Rails)
         writer.close
       end
 
@@ -127,7 +127,7 @@ module ScoutApm
         begin
           Process.kill('TERM', process_id.to_i)
         rescue Errno::ENOENT, Errno::ESRCH => e
-          context.logger.error("Error occurred while removing collector process: #{e.message}")
+          context.logger.error("Error occurred while removing collector process from manager: #{e.message}")
         ensure
           File.delete(context.config.value('collector_pid_file'))
         end

--- a/lib/scout_apm/logging/state.rb
+++ b/lib/scout_apm/logging/state.rb
@@ -2,37 +2,67 @@
 
 module ScoutApm
   module Logging
-    # Responsibling for ensuring safe interprocess persitance around configuration state.
-    class Config::State # rubocop:disable Style/ClassAndModuleChildren
-      attr_reader :context
+    class Config
+      # Responsibling for ensuring safe interprocess persitance around configuration state.
+      class State
+        attr_reader :context
 
-      def initialize(context)
-        @context = context
-      end
+        def initialize(context)
+          @context = context
+        end
 
-      def load_state_from_file
-        return unless File.exist?(context.config.value('monitor_state_file'))
+        def load_state_from_file
+          return unless File.exist?(context.config.value('monitor_state_file'))
 
-        file_contents = File.read(context.config.value('monitor_state_file'))
-        JSON.parse(file_contents)
-      end
+          file_contents = File.read(context.config.value('monitor_state_file'))
+          JSON.parse(file_contents)
+        end
 
-      def flush_to_file! # rubocop:disable Metrics/AbcSize
-        Utils.ensure_directory_exists(context.config.value('monitor_state_file'))
+        def flush_to_file!(updated_log_locations = []) # rubocop:disable Metrics/AbcSize
+          Utils.ensure_directory_exists(context.config.value('monitor_state_file'))
 
-        File.open(context.config.value('monitor_state_file'), (File::RDWR | File::CREAT), 0o644) do |file|
-          file.flock(File::LOCK_EX)
+          File.open(context.config.value('monitor_state_file'), (File::RDWR | File::CREAT), 0o644) do |file|
+            file.flock(File::LOCK_EX)
 
-          # TODO: We will need to merge monitored_logs based on the data in the state file, and not
-          # what is currently in the config.
-          data = Config::ConfigState.get_values_to_set.each_with_object({}) do |key, memo|
-            memo[key] = context.config.value(key)
+            data = Config::ConfigState.get_values_to_set.each_with_object({}) do |key, memo|
+              memo[key] = context.config.value(key)
+            end
+
+            unless updated_log_locations.empty?
+              contents = file.read
+
+              olds_log_files = if contents.empty?
+                                 []
+                               else
+                                 current_data = JSON.parse(contents)
+                                 current_data['monitored_logs']
+                               end
+
+              data['monitored_logs'] = merge_and_dedup_log_locations(updated_log_locations, olds_log_files)
+            end
+
+            file.rewind # Move cursor to beginning of the file
+            file.truncate(0) # Truncate existing content
+            file.write(JSON.pretty_generate(data))
+          rescue StandardError => e
+            context.logger.error("Error occurred while flushing state to file: #{e.message}. Unlocking.")
+          ensure
+            file.flock(File::LOCK_UN)
+          end
+        end
+
+        private
+
+        # Should we add better detection for similar basenames but different paths?
+        # May be a bit tricky with tools like capistrano and releases paths differentiated by time.
+        def merge_and_dedup_log_locations(new_logs, old_logs)
+          # Take the new logs if duplication, as we could be in a newer release.
+          merged = (new_logs + old_logs).each_with_object({}) do |log_path, hash|
+            base_name = File.basename(log_path)
+            hash[base_name] ||= log_path
           end
 
-          file.rewind # Move cursor to beginning of the file
-          file.truncate(0) # Truncate existing content
-          file.write(JSON.pretty_generate(data))
-          file.flock(File::LOCK_UN)
+          merged.values
         end
       end
     end

--- a/lib/scout_apm_logging.rb
+++ b/lib/scout_apm_logging.rb
@@ -8,6 +8,8 @@ require 'scout_apm/logging/context'
 require 'scout_apm/logging/utils'
 require 'scout_apm/logging/state'
 
+require 'scout_apm/logging/loggers/capture'
+
 require 'scout_apm/logging/monitor_manager/manager'
 
 module ScoutApm
@@ -17,9 +19,11 @@ module ScoutApm
       # If we are in a Rails environment, setup the monitor daemon manager.
       class RailTie < ::Rails::Railtie
         initializer 'scout_apm_logging.monitor' do
-          unless Utils.skip_setup?
-            context = ScoutApm::Logging::MonitorManager.instance.context
+          context = ScoutApm::Logging::MonitorManager.instance.context
 
+          Loggers::Capture.new(context).capture_log_locations!
+
+          unless Utils.skip_setup?
             Utils.attempt_exclusive_lock(context) do
               ScoutApm::Logging::MonitorManager.instance.setup!
             end

--- a/spec/integration/loggers/capture_spec.rb
+++ b/spec/integration/loggers/capture_spec.rb
@@ -1,0 +1,76 @@
+require 'logger'
+
+require 'spec_helper'
+
+class ScoutTestLogger < ::Logger
+end
+
+describe ScoutApm::Logging::Loggers::Capture do
+  it 'should find the logger, capture the log destination, and rotate collector configs' do
+    ENV['SCOUT_MONITOR_INTERVAL'] = '10'
+    ENV['SCOUT_DELAY_FIRST_HEALTHCHECK'] = '10'
+    ENV['SCOUT_MONITOR_LOGS'] = 'true'
+
+    state_file_location = ScoutApm::Logging::MonitorManager.instance.context.config.value('monitor_state_file')
+    collector_pid_location = ScoutApm::Logging::MonitorManager.instance.context.config.value('collector_pid_file')
+    ScoutApm::Logging::Utils.ensure_directory_exists(state_file_location)
+
+    first_logger = ScoutTestLogger.new('/tmp/first_file.log')
+
+    # While we only use the ObjectSpace for the test logger, we need to wait for it to be captured.
+    wait_for_logger
+
+    similuate_railtie
+
+    # Give the process time to initialize, download the collector, and start it
+    wait_for_process_with_timeout!('otelcol-contrib', 20)
+
+    expect(`pgrep otelcol-contrib --runstates D,R,S`).not_to be_empty
+    collector_pid = File.read(collector_pid_location)
+
+    content = File.read(state_file_location)
+    data = JSON.parse(content)
+    expect(data['monitored_logs']).to eq(['/tmp/first_file.log'])
+
+    second_logger = ScoutTestLogger.new('/tmp/second_file.log')
+
+    similuate_railtie
+
+    content = File.read(state_file_location)
+    data = JSON.parse(content)
+
+    first_log_path = first_logger.instance_variable_get(:@logdev).filename.to_s
+    second_log_path = second_logger.instance_variable_get(:@logdev).filename.to_s
+    expect(data['monitored_logs'].sort).to eq([first_log_path, second_log_path])
+
+    # Need to wait for the delay first health check, next monitor interval to restart the collector, and then for
+    # the collector to restart
+    sleep 60
+
+    expect(`pgrep otelcol-contrib --runstates D,R,S`).not_to be_empty
+    new_collector_pid = File.read(collector_pid_location)
+
+    # Should have restarted the collector based on the change
+    expect(new_collector_pid).not_to eq(collector_pid)
+  end
+
+  private
+
+  def similuate_railtie
+    context = ScoutApm::Logging::MonitorManager.instance.context
+
+    ScoutApm::Logging::Loggers::Capture.new(context).capture_log_locations!
+    ScoutApm::Logging::MonitorManager.new.setup!
+  end
+
+  def wait_for_logger
+    start_time = Time.now
+    loop do
+      break if ObjectSpace.each_object(ScoutTestLogger).count.positive?
+
+      raise 'Timed out while waiting for logger in ObjectSpace' if Time.now - start_time > 10
+
+      sleep 0.1
+    end
+  end
+end

--- a/spec/integration/monitor/collector/downloader/will_verify_checksum.rb
+++ b/spec/integration/monitor/collector/downloader/will_verify_checksum.rb
@@ -5,6 +5,7 @@ require_relative '../../../../../lib/scout_apm/logging/monitor/collector/downloa
 describe ScoutApm::Logging::Collector::Downloader do
   it 'should validate checksum, and correct download if neccessary' do
     ENV['SCOUT_MONITOR_LOGS'] = 'true'
+    ENV['SCOUT_MONITORED_LOGS'] = '["/tmp/test.log"]'
 
     otelcol_contrib_path = '/tmp/scout_apm/otelcol-contrib'
     ScoutApm::Logging::Utils.ensure_directory_exists(otelcol_contrib_path)
@@ -22,7 +23,7 @@ describe ScoutApm::Logging::Collector::Downloader do
 
     ENV['SCOUT_MONITOR_LOGS'] = 'false'
 
-    ScoutApm::Logging::MonitorManager.instance.setup!
+    ScoutApm::Logging::MonitorManager.new.setup!
 
     sleep 5 # Give the process time to exit
 
@@ -32,7 +33,7 @@ describe ScoutApm::Logging::Collector::Downloader do
 
     ENV['SCOUT_MONITOR_LOGS'] = 'true'
 
-    ScoutApm::Logging::MonitorManager.instance.setup!
+    ScoutApm::Logging::MonitorManager.new.setup!
 
     # Give the process time to exit, and for the healthcheck to restart it
     wait_for_process_with_timeout!('otelcol-contrib', 30)

--- a/spec/integration/monitor/collector_healthcheck_spec.rb
+++ b/spec/integration/monitor/collector_healthcheck_spec.rb
@@ -7,6 +7,8 @@ describe ScoutApm::Logging::Monitor do
     ENV['SCOUT_MONITOR_INTERVAL'] = '10'
     ENV['SCOUT_DELAY_FIRST_HEALTHCHECK'] = '10'
     ENV['SCOUT_MONITOR_LOGS'] = 'true'
+    ENV['SCOUT_MONITORED_LOGS'] = '["/tmp/test.log"]'
+
     ScoutApm::Logging::Utils.ensure_directory_exists('/tmp/scout_apm/scout_apm_log_monitor.pid')
 
     ScoutApm::Logging::MonitorManager.instance.setup!

--- a/spec/integration/monitor/previous_collector_setup_spec.rb
+++ b/spec/integration/monitor/previous_collector_setup_spec.rb
@@ -5,6 +5,8 @@ require_relative '../../../lib/scout_apm/logging/monitor/monitor'
 describe ScoutApm::Logging::Monitor do
   it 'should use previous collector setup if monitor daemon exits' do
     ENV['SCOUT_MONITOR_LOGS'] = 'true'
+    ENV['SCOUT_MONITORED_LOGS'] = '["/tmp/test.log"]'
+
     monitor_pid_location = ScoutApm::Logging::MonitorManager.instance.context.config.value('monitor_pid_file')
     collector_pid_location = ScoutApm::Logging::MonitorManager.instance.context.config.value('collector_pid_file')
     ScoutApm::Logging::Utils.ensure_directory_exists(monitor_pid_location)
@@ -21,7 +23,9 @@ describe ScoutApm::Logging::Monitor do
 
     `kill -9 #{monitor_pid}`
 
-    ScoutApm::Logging::MonitorManager.instance.setup!
+    # Create a separate monitor manager instance, or else we won't reload
+    # the configuraiton state.
+    ScoutApm::Logging::MonitorManager.new.setup!
 
     sleep 5
 

--- a/spec/integration/monitor_manager/disable_agent_spec.rb
+++ b/spec/integration/monitor_manager/disable_agent_spec.rb
@@ -5,6 +5,8 @@ require_relative '../../../lib/scout_apm/logging/monitor/collector/manager'
 describe ScoutApm::Logging::Collector::Manager do
   it 'If monitor is false, it should remove the daemon and collector process if they are present' do
     ENV['SCOUT_MONITOR_LOGS'] = 'true'
+    ENV['SCOUT_MONITORED_LOGS'] = '["/tmp/test.log"]'
+
     expect(`pgrep otelcol-contrib --runstates D,R,S`).to be_empty
 
     ScoutApm::Logging::MonitorManager.instance.setup!
@@ -13,7 +15,7 @@ describe ScoutApm::Logging::Collector::Manager do
 
     ENV['SCOUT_MONITOR_LOGS'] = 'false'
 
-    ScoutApm::Logging::MonitorManager.instance.setup!
+    ScoutApm::Logging::MonitorManager.new.setup!
 
     sleep 5 # Give the process time to exit
 

--- a/spec/integration/monitor_manager/monitor_pid_file_spec.rb
+++ b/spec/integration/monitor_manager/monitor_pid_file_spec.rb
@@ -5,6 +5,8 @@ require_relative '../../../lib/scout_apm/logging/monitor/collector/manager'
 describe ScoutApm::Logging::Collector::Manager do
   it 'should recreate the monitor process if monitor.pid file is errant' do
     ENV['SCOUT_MONITOR_LOGS'] = 'true'
+    ENV['SCOUT_MONITORED_LOGS'] = '["/tmp/test.log"]'
+
     ScoutApm::Logging::Utils.ensure_directory_exists('/tmp/scout_apm/scout_apm_log_monitor.pid')
 
     # A high enough number to not be a PID of a running process

--- a/spec/integration/monitor_manager/single_monitor_spec.rb
+++ b/spec/integration/monitor_manager/single_monitor_spec.rb
@@ -10,6 +10,7 @@ require 'spec_helper'
 describe ScoutApm::Logging do
   it 'Should only create a single monitor daemon if manager is called multiple times' do
     ENV['SCOUT_MONITOR_LOGS'] = 'true'
+    ENV['SCOUT_MONITORED_LOGS'] = '["/tmp/test.log"]'
 
     pid_file = ScoutApm::Logging::MonitorManager.instance.context.config.value('monitor_pid_file')
     expect(File.exist?(pid_file)).to be_falsey
@@ -21,7 +22,7 @@ describe ScoutApm::Logging do
         puts 'fork attempting to gain lock'
         ScoutApm::Logging::Utils.attempt_exclusive_lock(context) do
           puts 'obtained lock'
-          ScoutApm::Logging::MonitorManager.instance.setup!
+          ScoutApm::Logging::MonitorManager.new.setup!
         end
       end
     end
@@ -40,7 +41,7 @@ describe ScoutApm::Logging do
     # Another process comes in and tries to start it again
     ScoutApm::Logging::Utils.attempt_exclusive_lock(context) do
       puts 'obtained lock later on'
-      ScoutApm::Logging::MonitorManager.instance.setup!
+      ScoutApm::Logging::MonitorManager.new.setup!
     end
 
     expect(File.exist?(context.config.value('manager_lock_file'))).to be_falsey

--- a/spec/integration/rails/lifecycle_spec.rb
+++ b/spec/integration/rails/lifecycle_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe ScoutApm::Logging do
   it 'checks the Rails lifecycle for creating the daemon and collector processes' do
     ENV['SCOUT_MONITOR_LOGS'] = 'true'
+    ENV['SCOUT_MONITORED_LOGS'] = '["/tmp/test.log"]'
 
     pid_file = ScoutApm::Logging::MonitorManager.instance.context.config.value('monitor_pid_file')
     expect(File.exist?(pid_file)).to be_falsey

--- a/spec/unit/state_spec.rb
+++ b/spec/unit/state_spec.rb
@@ -10,7 +10,7 @@ describe ScoutApm::Logging::Config do
 
     ScoutApm::Logging::Config::ConfigDynamic.set_value('health_check_port', 1234)
 
-    context.config.flush_state!
+    context.config.state.flush_state!
 
     data = ScoutApm::Logging::Config::State.new(context).load_state_from_file
 


### PR DESCRIPTION
Adds the ability to read the log devices off both Rails and Sidekiq logger. It then takes the paths from the devices and adds them to the state manager.

The monitor daemon will now keep track of the current state file, and if it notices a change, it will restart the collector with the updated state (ultimately, this would occur if a new file gets added to the state manager)