### PR TITLE
Add proxy logger

### DIFF
--- a/lib/scout_apm/logging/config.rb
+++ b/lib/scout_apm/logging/config.rb
@@ -28,6 +28,7 @@ module ScoutApm
         health_check_port
         delay_first_healthcheck
         logs_config
+        proxy_log_dir
       ].freeze
 
       SETTING_COERCIONS = {
@@ -198,7 +199,8 @@ module ScoutApm
           'monitored_logs' => [],
           'logs_reporting_endpoint' => 'https://otlp.telemetryhub.com:4317',
           'monitor_interval' => 60,
-          'delay_first_healthcheck' => 60
+          'delay_first_healthcheck' => 60,
+          'proxy_log_dir' => '/tmp/scout_apm/logs/'
         }.freeze
 
         def value(key)

--- a/lib/scout_apm/logging/loggers/capture.rb
+++ b/lib/scout_apm/logging/loggers/capture.rb
@@ -2,6 +2,10 @@
 
 require 'logger'
 
+require_relative './swap'
+require_relative './proxy'
+require_relative './destination'
+
 module ScoutApm
   module Logging
     module Loggers
@@ -14,24 +18,13 @@ module ScoutApm
         end
 
         def capture_log_locations! # rubocop:disable Metrics/AbcSize
-          logger_instances = []
-
           logger_instances << Rails.logger if defined?(Rails)
           logger_instances << Sidekiq.logger if defined?(Sidekiq)
           logger_instances << ObjectSpace.each_object(::ScoutTestLogger).to_a if defined?(::ScoutTestLogger)
-          logger_instances.flatten!
 
-          updated_log_locations = []
-          logger_instances.each do |log_instance|
-            log_devices = get_log_devices(log_instance)
-            log_locations = get_log_location(log_devices)
-
-            log_locations.each do |location|
-              # TODO: Add a proxy logger if we are logging to STDOUT
-              next if location == $stdout
-
-              updated_log_locations << location
-            end
+          # Swap in our logger for each logger instance, in conjunction with the original class.
+          updated_log_locations = logger_instances.compact.flatten.map do |logger|
+            swapped_in_location(logger)
           end
 
           context.config.state.add_log_locations!(updated_log_locations)
@@ -39,31 +32,14 @@ module ScoutApm
 
         private
 
-        # In Rails 7.1, broadcast logger was added which allows sinking to multiple IO devices.
-        def get_log_devices(log_instance)
-          # https://github.com/rails/rails/blob/main/activesupport/lib/active_support/logger.rb#L20
-          loggers =
-            if defined?(ActiveSupport::BroadcastLogger) && log_instance.is_a?(ActiveSupport::BroadcastLogger)
-              log_instance.broadcasts
-            else
-              [log_instance]
-            end
-
-          loggers.map { |logger| logger.instance_variable_get(:@logdev) }
+        def logger_instances
+          @logger_instances ||= []
         end
 
-        def get_log_location(log_devices)
-          locations = log_devices.map do |logdev|
-            if logdev.respond_to?(:filename)
-              puts logdev.filename
-              logdev.filename
-            elsif logdev.respond_to?(:dev)
-              device = logdev.dev
-              device.respond_to?(:path) ? device.path : device
-            end
-          end
-
-          locations.compact
+        def swapped_in_location(log_instance)
+          swap = Swap.new(context, log_instance)
+          swap.update_logger!
+          swap.log_location
         end
       end
     end

--- a/lib/scout_apm/logging/loggers/destination.rb
+++ b/lib/scout_apm/logging/loggers/destination.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'logger'
+
+module ScoutApm
+  module Logging
+    module Loggers
+      class FileLogger < ::Logger
+      end
+
+      # The newly created logger which we can configure, and will log to a filepath.
+      class Destination
+        attr_reader :context, :log_instance
+
+        # 1 MiB
+        LOG_SIZE = 1024 * 1024
+        # 1 log file
+        LOG_AGE = 1
+
+        def initialize(context, log_instance)
+          @context = context
+          @log_instance = log_instance
+        end
+
+        def create_logger!
+          # Defaults are 7 files with 10 MiB.
+          FileLogger.new(determine_file_path, LOG_AGE, LOG_SIZE)
+        end
+
+        def determine_file_path # rubocop:disable Metrics/AbcSize
+          log_directory = context.config.value('proxy_log_dir')
+
+          original_basename = File.basename(log_destination) if log_destination.is_a?(String)
+
+          file_basename = if original_basename
+                            original_basename
+                          elsif defined?(::ActiveSupport::Logger) && log_instance.is_a?(::ActiveSupport::Logger)
+                            'rails.log'
+                          elsif defined?(::ActiveSupport::BroadcastLogger) && log_instance.is_a?(::ActiveSupport::BroadcastLogger)
+                            'rails.log'
+                          elsif defined?(::Sidekiq::Logger) && log_instance.is_a?(::Sidekiq::Logger)
+                            'sidekiq.log'
+                          elsif defined?(::ScoutTestLogger) && log_instance.is_a?(::ScoutTestLogger)
+                            'test.log'
+                          else
+                            'mix.log'
+                          end
+
+          File.join(log_directory, file_basename)
+        end
+
+        private
+
+        def find_log_destination(logdev)
+          dev = try(logdev, :filename) || try(logdev, :dev)
+          if dev.is_a?(String)
+            dev
+          elsif dev.respond_to?(:path)
+            dev.path
+          elsif dev.respond_to?(:filename) || dev.respond_to?(:dev)
+            find_log_destination(dev)
+          else
+            dev
+          end
+        end
+
+        def log_destination
+          @log_destination ||= find_log_destination(log_instance.instance_variable_get(:@logdev))
+        end
+
+        def try(obj, method)
+          obj.respond_to?(method) ? obj.send(method) : nil
+        end
+      end
+    end
+  end
+end

--- a/lib/scout_apm/logging/loggers/proxy.rb
+++ b/lib/scout_apm/logging/loggers/proxy.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'logger'
+
+module ScoutApm
+  module Logging
+    module Loggers
+      # Holds both the original application logger and the new one. Relays commands to both.
+      class Proxy
+        def initialize
+          @loggers = []
+        end
+
+        def add(logger)
+          @loggers << logger
+        end
+
+        def remove(logger)
+          @loggers.reject! { |inst_log| inst_log == logger }
+
+          @loggers
+        end
+
+        def method_missing(name, *args, &block)
+          # Some libraries will do stuff like Library.logger.formatter = Rails.logger.formatter
+          # As such, we should return the first logger's (the original logger) return value.
+          return_value = @loggers.first.send(name, *args, &block)
+          @loggers[1..].each { |logger| logger.send(name, *args, &block) }
+
+          return_value
+        end
+
+        def respond_to_missing?(name, *args)
+          @loggers.first.respond_to?(name, *args) || super
+        end
+      end
+    end
+  end
+end

--- a/lib/scout_apm/logging/loggers/swap.rb
+++ b/lib/scout_apm/logging/loggers/swap.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'logger'
+
+module ScoutApm
+  module Logging
+    module Loggers
+      # Swaps in our logger for the application's logger.
+      class Swap
+        attr_reader :context, :log_instance, :new_file_logger
+
+        def initialize(context, log_instance)
+          @context = context
+          @log_instance = log_instance
+        end
+
+        def update_logger!
+          create_proxy_log_dir!
+
+          # In Rails 7.1, broadcast logger was added which allows sinking to multiple IO devices.
+          if defined?(::ActiveSupport::BroadcastLogger) && log_instance.is_a?(::ActiveSupport::BroadcastLogger)
+            add_logger_to_broadcast!
+          else
+            swap_in_proxy_logger!
+          end
+        end
+
+        def log_location
+          new_file_logger.instance_variable_get(:@logdev).filename
+        end
+
+        private
+
+        def add_logger_to_broadcast!
+          @new_file_logger = create_destination_logger
+          log_instance.broadcast_to(new_file_logger)
+        end
+
+        def swap_in_proxy_logger! # rubocop:disable Metrics/AbcSize
+          proxy_logger = Proxy.new
+          # We can use the previous logdev. log_device will continuously call write
+          # through the devices until the logdev (@dev) is an IO device other than logdev:
+          # https://github.com/ruby/ruby/blob/master/lib/logger/log_device.rb#L42
+          # Log device holds the configurations around shifting too.
+          original_logdevice = log_instance.instance_variable_get(:@logdev)
+          updated_original_logger = ::Logger.new(original_logdevice)
+          updated_original_logger.formatter = log_instance.formatter
+
+          @new_file_logger = create_destination_logger
+
+          # First logger needs to be the original logger for the return value of relayed calls.
+          proxy_logger.add(updated_original_logger)
+          proxy_logger.add(new_file_logger)
+
+          if defined?(::ActiveSupport::Logger) && log_instance.is_a?(::ActiveSupport::Logger)
+            Rails.logger = proxy_logger
+          elsif defined?(::Sidekiq::Logger) && log_instance.is_a?(::Sidekiq::Logger)
+            Sidekiq.configure_server do |config|
+              config.logger = proxy_logger
+            end
+          elsif defined?(::ScoutTestLogger) && log_instance.is_a?(::ScoutTestLogger)
+            TestLoggerWrapper.logger = proxy_logger
+          end
+        end
+
+        def create_destination_logger
+          Destination.new(context, log_instance).create_logger!
+        end
+
+        def create_proxy_log_dir!
+          Utils.ensure_directory_exists(context.config.value('proxy_log_dir'))
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,15 @@ require "action_view/railtie"
 # Require after rails, to ensure the railtie is ran
 require 'scout_apm_logging'
 
+class TestLoggerWrapper
+  class << self
+    attr_accessor :logger
+  end
+end
+
+class ScoutTestLogger < ::Logger
+end
+
 RSpec.configure do |config|
   ENV["SCOUT_LOG_LEVEL"] = "debug"
 

--- a/spec/unit/loggers/capture_spec.rb
+++ b/spec/unit/loggers/capture_spec.rb
@@ -1,0 +1,47 @@
+require 'logger'
+require 'stringio'
+
+require 'spec_helper'
+
+require_relative '../../../lib/scout_apm/logging/loggers/capture'
+
+def capture_stdout
+  old_stdout = $stdout
+  $stdout = StringIO.new
+  yield
+  $stdout.string
+ensure
+  $stdout = old_stdout
+end
+
+describe ScoutApm::Logging::Loggers::Capture do
+  it 'should swap the STDOUT logger and create a proxy logger' do
+    ENV['SCOUT_MONITOR_INTERVAL'] = '10'
+    ENV['SCOUT_DELAY_FIRST_HEALTHCHECK'] = '10'
+    ENV['SCOUT_MONITOR_LOGS'] = 'true'
+
+    output_from_log = capture_stdout do
+      context = ScoutApm::Logging::Context.new
+      conf_file = File.expand_path('../data/config_test_1.yml', __dir__)
+      conf = ScoutApm::Logging::Config.with_file(context, conf_file)
+      context.config = conf
+
+      ScoutTestLogger.new($stdout)
+
+      capture = ScoutApm::Logging::Loggers::Capture.new(context)
+      capture.capture_log_locations!
+
+      TestLoggerWrapper.logger.info('TEST')
+
+      log_path = File.join(context.config.value('proxy_log_dir'), 'test.log')
+      content = File.read(log_path)
+      expect(content).to include('TEST')
+
+      state_file = File.read(context.config.value('monitor_state_file'))
+      state_data = JSON.parse(state_file)
+      expect(state_data['monitored_logs']).to eq([log_path])
+    end
+
+    expect(output_from_log).to include('TEST')
+  end
+end


### PR DESCRIPTION
Adds a proxy logger which gets swapped in for both the Rails logger and Sidekiq logger. This proxy logger contains the original logger as well as a new logger that we create that logs to a file. This way, we can capture logs that we bound to STDOUT using the file receiver (and our new logger) without disrupting the original. We do apply this proxy logger to all loggers, and not just those bound for STDOUT, as this allows us to control the formatting of the log

This proxy logger is swapped in for sidekiq and Rails versions less 7.1, where in Rails 7.1 and greater we add our logger to the broadcast logger