### PR TITLE
Prevent setup in build and console

### DIFF
--- a/lib/scout_apm/logging/utils.rb
+++ b/lib/scout_apm/logging/utils.rb
@@ -43,6 +43,14 @@ module ScoutApm
 
         true
       end
+
+      def self.skip_setup?
+        [
+          ARGV.include?('assets:precompile'),
+          ARGV.include?('assets:clean'),
+          (defined?(::Rails::Console) && $stdout.isatty && $stdin.isatty)
+        ].any?
+      end
     end
   end
 end

--- a/lib/scout_apm_logging.rb
+++ b/lib/scout_apm_logging.rb
@@ -16,7 +16,7 @@ module ScoutApm
       # If we are in a Rails environment, setup the monitor daemon manager.
       class RailTie < ::Rails::Railtie
         initializer 'scout_apm_logging.monitor' do
-          ScoutApm::Logging::MonitorManager.instance.setup!
+          ScoutApm::Logging::MonitorManager.instance.setup! unless Utils.skip_setup?
         end
       end
     end


### PR DESCRIPTION
Prevent setup if we are either building the application, or if we are accessing the console.

This prevents a situation where during the assets:precompile & assets:clean, and potentially related to us spawning a ruby process, the heroku deploy/buildpack appears to stop and the deploy hangs.