### PR TITLE
Add exclusion lock as well as fix daemonization and process detection

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,7 +15,7 @@ Metrics/BlockLength:
     - "spec/**/*"
 
 Metrics/ClassLength:
-  Max: 120
+  Max: 130
 
 Style/FrozenStringLiteralComment:
   EnforcedStyle: always

--- a/lib/scout_apm/logging/config.rb
+++ b/lib/scout_apm/logging/config.rb
@@ -21,6 +21,7 @@ module ScoutApm
         collector_download_dir
         collector_config_file
         collector_version
+        manager_lock_file
         monitored_logs
         logs_reporting_endpoint
         monitor_interval
@@ -105,6 +106,7 @@ module ScoutApm
           'collector_download_dir' => '/tmp/scout_apm/',
           'collector_config_file' => '/tmp/scout_apm/config.yml',
           'collector_version' => '0.102.1',
+          'manager_lock_file' => '/tmp/scout_apm/monitor_lock_file.lock',
           'monitored_logs' => [],
           'logs_reporting_endpoint' => 'https://otlp.telemetryhub.com:4317',
           'monitor_interval' => 60,

--- a/lib/scout_apm/logging/monitor/monitor.rb
+++ b/lib/scout_apm/logging/monitor/monitor.rb
@@ -34,7 +34,7 @@ module ScoutApm
         Config::ConfigDynamic.set_value('monitored_logs', [assumed_rails_log_path])
         context.config = Config.with_file(context, determine_scout_config_filepath)
 
-        check_process_then_daemonize!
+        daemonize_process!
       end
 
       def setup!
@@ -70,9 +70,8 @@ module ScoutApm
 
       private
 
-      def check_process_then_daemonize!
+      def daemonize_process!
         # Similar to that of Process.daemon, but we want to keep the dir, STDOUT and STDERR.
-        # Relevant: https://workingwithruby.com/wwup/daemons/
         exit if fork
         Process.setsid
         exit if fork

--- a/lib/scout_apm/logging/monitor/monitor.rb
+++ b/lib/scout_apm/logging/monitor/monitor.rb
@@ -70,10 +70,6 @@ module ScoutApm
 
       private
 
-      def exit_if_we_arent_only_monitor
-        exit if Utils.process_of_same_name_count?($PROGRAM_NAME) > 1
-      end
-
       def check_process_then_daemonize!
         # Similar to that of Process.daemon, but we want to keep the dir, STDOUT and STDERR.
         # Relevant: https://workingwithruby.com/wwup/daemons/
@@ -81,8 +77,6 @@ module ScoutApm
         Process.setsid
         exit if fork
         $stdin.reopen '/dev/null'
-
-        exit_if_we_arent_only_monitor
 
         File.write(context.config.value('monitor_pid_file'), Process.pid)
       end

--- a/lib/scout_apm/logging/monitor_manager/manager.rb
+++ b/lib/scout_apm/logging/monitor_manager/manager.rb
@@ -25,7 +25,7 @@ module ScoutApm
 
         determine_configuration_state
 
-        # Continue to hold the exclusive write until we have written the PID file.
+        # Continue to hold the lock until we have written the PID file.
         ensure_monitor_pid_file_exists
       end
 

--- a/lib/scout_apm/logging/utils.rb
+++ b/lib/scout_apm/logging/utils.rb
@@ -30,10 +30,6 @@ module ScoutApm
         end
       end
 
-      def self.process_of_same_name_count?(command)
-        `ps aux | grep '#{command}' | grep -v grep | wc -l`.to_i
-      end
-
       def self.check_process_liveliness(pid, name)
         # Pipe to cat to prevent truncation of the output
         process_information = `ps -p #{pid} -o pid=,stat=,command= | cat`

--- a/lib/scout_apm/logging/utils.rb
+++ b/lib/scout_apm/logging/utils.rb
@@ -30,6 +30,10 @@ module ScoutApm
         end
       end
 
+      def self.process_of_same_name_count?(command)
+        `ps aux | grep '#{command}' | grep -v grep | wc -l`.to_i
+      end
+
       def self.check_process_liveliness(pid, name)
         # Pipe to cat to prevent truncation of the output
         process_information = `ps -p #{pid} -o pid=,stat=,command= | cat`
@@ -42,6 +46,16 @@ module ScoutApm
         return false unless process_information.include?(name)
 
         true
+      end
+
+      def self.current_process_is_app_server?
+        # TODO: Add more app servers.
+        process_command = `ps -p #{Process.pid} -o command= | cat`.downcase
+        [
+          process_command.include?('puma'),
+          process_command.include?('unicorn'),
+          process_command.include?('passenger')
+        ].any?
       end
 
       def self.skip_setup?

--- a/lib/scout_apm_logging.rb
+++ b/lib/scout_apm_logging.rb
@@ -16,7 +16,32 @@ module ScoutApm
       # If we are in a Rails environment, setup the monitor daemon manager.
       class RailTie < ::Rails::Railtie
         initializer 'scout_apm_logging.monitor' do
-          ScoutApm::Logging::MonitorManager.instance.setup! unless Utils.skip_setup?
+          def self.attempt_exclusive_lock
+            context = ScoutApm::Logging::MonitorManager.instance.context
+            lock_file = context.config.value('manager_lock_file')
+            Utils.ensure_directory_exists(lock_file)
+
+            begin
+              file = File.open(lock_file, File::RDWR | File::CREAT | File::EXCL)
+            rescue Errno::EEXIST
+              context.logger.debug('Exclusive lock file held, continuing.')
+              return
+            end
+
+            # Ensure the lock file is deleted when the block completes
+            begin
+              yield
+            ensure
+              file.close
+              File.delete(lock_file) if File.exist?(lock_file)
+            end
+          end
+
+          unless Utils.skip_setup?
+            attempt_exclusive_lock do
+              ScoutApm::Logging::MonitorManager.instance.setup! unless Utils.skip_setup?
+            end
+          end
         end
       end
     end

--- a/lib/scout_apm_logging.rb
+++ b/lib/scout_apm_logging.rb
@@ -16,30 +16,11 @@ module ScoutApm
       # If we are in a Rails environment, setup the monitor daemon manager.
       class RailTie < ::Rails::Railtie
         initializer 'scout_apm_logging.monitor' do
-          def self.attempt_exclusive_lock
-            context = ScoutApm::Logging::MonitorManager.instance.context
-            lock_file = context.config.value('manager_lock_file')
-            Utils.ensure_directory_exists(lock_file)
-
-            begin
-              file = File.open(lock_file, File::RDWR | File::CREAT | File::EXCL)
-            rescue Errno::EEXIST
-              context.logger.debug('Exclusive lock file held, continuing.')
-              return
-            end
-
-            # Ensure the lock file is deleted when the block completes
-            begin
-              yield
-            ensure
-              file.close
-              File.delete(lock_file) if File.exist?(lock_file)
-            end
-          end
-
           unless Utils.skip_setup?
-            attempt_exclusive_lock do
-              ScoutApm::Logging::MonitorManager.instance.setup! unless Utils.skip_setup?
+            context = ScoutApm::Logging::MonitorManager.instance.context
+
+            Utils.attempt_exclusive_lock(context) do
+              ScoutApm::Logging::MonitorManager.instance.setup!
             end
           end
         end

--- a/spec/integration/monitor_manager/single_monitor_spec.rb
+++ b/spec/integration/monitor_manager/single_monitor_spec.rb
@@ -14,14 +14,36 @@ describe ScoutApm::Logging do
     pid_file = ScoutApm::Logging::MonitorManager.instance.context.config.value('monitor_pid_file')
     expect(File.exist?(pid_file)).to be_falsey
 
-    ScoutApm::Logging::MonitorManager.instance.setup!
+    context = ScoutApm::Logging::MonitorManager.instance.context
+
+    pids = 3.times.map do
+      fork do
+        puts 'fork attempting to gain lock'
+        ScoutApm::Logging::Utils.attempt_exclusive_lock(context) do
+          puts 'obtained lock'
+          ScoutApm::Logging::MonitorManager.instance.setup!
+        end
+      end
+    end
+
+    pids.each { |pid| Process.wait(pid) }
+
     wait_for_process_with_timeout!('otelcol-contrib', 20)
 
+    # The file lock really should be gone at this point.
+    expect(File.exist?(context.config.value('manager_lock_file'))).to be_falsey
     expect(File.exist?(pid_file)).to be_truthy
+
     original_pid = File.read(pid_file).to_i
     expect(ScoutApm::Logging::Utils.check_process_liveliness(original_pid, 'scout_apm_logging_monitor')).to be_truthy
 
-    ScoutApm::Logging::MonitorManager.instance.setup!
+    # Another process comes in and tries to start it again
+    ScoutApm::Logging::Utils.attempt_exclusive_lock(context) do
+      puts 'obtained lock later on'
+      ScoutApm::Logging::MonitorManager.instance.setup!
+    end
+
+    expect(File.exist?(context.config.value('manager_lock_file'))).to be_falsey
     expect(File.exist?(pid_file)).to be_truthy
     updated_pid = File.read(pid_file).to_i
     expect(updated_pid).to eq(original_pid)

--- a/spec/integration/monitor_manager/single_monitor_spec.rb
+++ b/spec/integration/monitor_manager/single_monitor_spec.rb
@@ -15,6 +15,7 @@ describe ScoutApm::Logging do
     expect(File.exist?(pid_file)).to be_falsey
 
     ScoutApm::Logging::MonitorManager.instance.setup!
+    wait_for_process_with_timeout!('otelcol-contrib', 20)
 
     expect(File.exist?(pid_file)).to be_truthy
     original_pid = File.read(pid_file).to_i

--- a/spec/integration/rails/lifecycle_spec.rb
+++ b/spec/integration/rails/lifecycle_spec.rb
@@ -9,7 +9,9 @@ describe ScoutApm::Logging do
 
     make_basic_app
 
-    # Check if the PID file exists
+    wait_for_process_with_timeout!('otelcol-contrib', 20)
+
+    # Check if the monitor PID file exists
     expect(File.exist?(pid_file)).to be_truthy
 
     # Read the PID from the PID file
@@ -17,11 +19,6 @@ describe ScoutApm::Logging do
 
     # Check if the process with the stored PID is running
     expect(ScoutApm::Logging::Utils.check_process_liveliness(pid, 'scout_apm_logging_monitor')).to be_truthy
-
-    # Give the process time to initialize, download the collector, and start it
-    wait_for_process_with_timeout!(
-      'otelcol-contrib', 20
-    )
 
     # Kill the process and ensure PID file clean up
     Process.kill('TERM', pid)


### PR DESCRIPTION
Adds an exclusion lock as well as fixes the daemonization of the monitor process and app server process detection.

Adds an exclusion lock to the Rails railtie initializer allowing only 1 process to try and setup the manager and subsequently the monitor process and collector at a time. This does add a little bit of overhead / delay to the initial Rails boot time (roughly 30-40ms on some local crude/naive benchmarks) -- Note: the setting up of the manager and monitor isn't a middleware, and does _not_ occur for each request. We could make a configuration value that allows this to be disabled, say if someone is using containers and there is only one Rails process.

Originally, we were only changing the pgroup when launching the new process. This caused issues as when sending a signal to the Rails process, it would wait for the child process to exit (which we don't intend for it to do, except when it's the app server exiting).

Updates the app server process detection in the exit handler to happen at exit, as the process command line changes at some point to include the app server name.