### PR TITLE
Add log formatter

### DIFF
--- a/lib/scout_apm/logging/loggers/capture.rb
+++ b/lib/scout_apm/logging/loggers/capture.rb
@@ -4,7 +4,6 @@ require 'logger'
 
 require_relative './swap'
 require_relative './proxy'
-require_relative './destination'
 
 module ScoutApm
   module Logging

--- a/lib/scout_apm/logging/loggers/destination.rb
+++ b/lib/scout_apm/logging/loggers/destination.rb
@@ -24,6 +24,8 @@ module ScoutApm
 
         def create_logger!
           # Defaults are 7 files with 10 MiB.
+          # We create the file in order to prevent a creation header log.
+          File.new(determine_file_path, 'w+')
           FileLogger.new(determine_file_path, LOG_AGE, LOG_SIZE)
         end
 

--- a/lib/scout_apm/logging/loggers/formatter.rb
+++ b/lib/scout_apm/logging/loggers/formatter.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'logger'
+
+module ScoutApm
+  module Logging
+    module Loggers
+      # A simple JSON formatter which we can add a couple attributes to.
+      class Formatter < ::Logger::Formatter
+        DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%S.%LZ'
+
+        def call(severity, time, progname, msg) # rubocop:disable Metrics/AbcSize
+          attributes_to_log[:severity] = severity
+          attributes_to_log[:time] = format_datetime(time)
+          attributes_to_log[:progname] = progname if progname
+          attributes_to_log[:pid] = Process.pid
+          attributes_to_log[:msg] = msg2str(msg)
+          attributes_to_log['service.name'] = service_name
+
+          "#{attributes_to_log.to_json}\n"
+        end
+
+        private
+
+        def attributes_to_log
+          @attributes_to_log ||= {}
+        end
+
+        def format_datetime(time)
+          time.utc.strftime(DATETIME_FORMAT)
+        end
+
+        # We may need to clean this up a bit.
+        def service_name
+          $PROGRAM_NAME
+        end
+      end
+    end
+  end
+end

--- a/lib/scout_apm/logging/loggers/logger.rb
+++ b/lib/scout_apm/logging/loggers/logger.rb
@@ -9,7 +9,7 @@ module ScoutApm
       end
 
       # The newly created logger which we can configure, and will log to a filepath.
-      class Destination
+      class Logger
         attr_reader :context, :log_instance
 
         # 1 MiB
@@ -25,7 +25,7 @@ module ScoutApm
         def create_logger!
           # Defaults are 7 files with 10 MiB.
           # We create the file in order to prevent a creation header log.
-          File.new(determine_file_path, 'w+')
+          File.new(determine_file_path, 'w+') unless File.exist?(determine_file_path)
           FileLogger.new(determine_file_path, LOG_AGE, LOG_SIZE)
         end
 

--- a/lib/scout_apm/logging/loggers/swap.rb
+++ b/lib/scout_apm/logging/loggers/swap.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'json'
 require 'logger'
 
 module ScoutApm
@@ -33,6 +34,8 @@ module ScoutApm
 
         def add_logger_to_broadcast!
           @new_file_logger = create_destination_logger
+          @new_file_logger.formatter = simple_json_formatter
+
           log_instance.broadcast_to(new_file_logger)
         end
 
@@ -47,6 +50,7 @@ module ScoutApm
           updated_original_logger.formatter = log_instance.formatter
 
           @new_file_logger = create_destination_logger
+          @new_file_logger.formatter = simple_json_formatter
 
           # First logger needs to be the original logger for the return value of relayed calls.
           proxy_logger.add(updated_original_logger)
@@ -69,6 +73,12 @@ module ScoutApm
 
         def create_proxy_log_dir!
           Utils.ensure_directory_exists(context.config.value('proxy_log_dir'))
+        end
+
+        def simple_json_formatter
+          proc do |severity, datetime, progname, msg|
+            "#{{ severity: severity, datetime: datetime, progname: progname, msg: msg }.to_json}\n"
+          end
         end
       end
     end

--- a/lib/scout_apm/logging/monitor/collector/configuration.rb
+++ b/lib/scout_apm/logging/monitor/collector/configuration.rb
@@ -79,7 +79,16 @@ module ScoutApm
               filelog:
                 include: [#{context.config.value('monitored_logs').join(',')}]
                 storage: file_storage/filelogreceiver
+                operators:
+                  - type: json_parser
+                    severity:
+                      parse_from: attributes.severity
             processors:
+              transform:
+                log_statements:
+                  - context: log
+                    statements:
+                    - 'set(body, attributes["msg"])'
               batch:
             exporters:
               otlp:
@@ -106,6 +115,7 @@ module ScoutApm
                   receivers:
                     - filelog
                   processors:
+                    - transform
                     - batch
                   exporters:
                     - otlp

--- a/lib/scout_apm/logging/monitor/collector/configuration.rb
+++ b/lib/scout_apm/logging/monitor/collector/configuration.rb
@@ -83,12 +83,18 @@ module ScoutApm
                   - type: json_parser
                     severity:
                       parse_from: attributes.severity
+                    timestamp:
+                      parse_from: attributes.time
+                      layout: "%Y-%m-%dT%H:%M:%S.%LZ"
             processors:
               transform:
                 log_statements:
                   - context: log
                     statements:
+                    # Replace the body with the log message.
                     - 'set(body, attributes["msg"])'
+                    # Move service.name attribute to resource attribute.
+                    - 'set(resource.attributes["service.name"], attributes["service.name"])'
               batch:
             exporters:
               otlp:


### PR DESCRIPTION
Adds a custom JSON formatter to the newly created logger. This also allows us to add additional attributes to the log format which we can then utilize in both the collector's parsers and transformers. We may want to improve the service.name at some point, as I don't believe it will be able to discern whether something is say, a Rails Runner or the actual Rails webserver process.

Renames the created logger class to Logger from Destination