### PR TITLE
Fix state file sha checking

### DIFF
--- a/lib/scout_apm/logging/monitor/monitor.rb
+++ b/lib/scout_apm/logging/monitor/monitor.rb
@@ -35,8 +35,6 @@ module ScoutApm
         # Load in the dynamic and state based config settings.
         context.config = Config.with_file(context, determine_scout_config_filepath)
 
-        @latest_state_sha = get_state_file_sha
-
         daemonize_process!
       end
 
@@ -51,6 +49,8 @@ module ScoutApm
         end
 
         initiate_collector_setup! unless has_previous_collector_setup?
+
+        @latest_state_sha = get_state_file_sha
 
         run!
       end
@@ -191,6 +191,9 @@ module ScoutApm
 
         remove_collector_process
         initiate_collector_setup!
+
+        # File SHA can change due to port mappings on collector setup.
+        @latest_state_sha = get_state_file_sha
       end
 
       def add_exit_handler!

--- a/spec/integration/loggers/capture_spec.rb
+++ b/spec/integration/loggers/capture_spec.rb
@@ -46,7 +46,8 @@ describe ScoutApm::Logging::Loggers::Capture do
 
     # Need to wait for the delay first health check, next monitor interval to restart the collector, and then for
     # the collector to restart
-    sleep 60
+    sleep 25
+    wait_for_process_with_timeout!('otelcol-contrib', 20)
 
     expect(`pgrep otelcol-contrib --runstates D,R,S`).not_to be_empty
     new_collector_pid = File.read(collector_pid_location)

--- a/spec/integration/monitor/continuous_state_collector_spec.rb
+++ b/spec/integration/monitor/continuous_state_collector_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+require_relative '../../../lib/scout_apm/logging/monitor/monitor'
+
+describe ScoutApm::Logging::Monitor do
+  it "Should not restart the collector if the state hasn't changed" do
+    ENV['SCOUT_MONITOR_INTERVAL'] = '10'
+    ENV['SCOUT_DELAY_FIRST_HEALTHCHECK'] = '10'
+    ENV['SCOUT_MONITOR_LOGS'] = 'true'
+    ENV['SCOUT_MONITORED_LOGS'] = '["/tmp/test.log"]'
+
+    context = ScoutApm::Logging::MonitorManager.instance.context
+    collector_pid_location = context.config.value('collector_pid_file')
+    ScoutApm::Logging::MonitorManager.instance.setup!
+    # Give the process time to initialize, download the collector, and start it
+    wait_for_process_with_timeout!('otelcol-contrib', 20)
+
+    expect(`pgrep otelcol-contrib --runstates D,R,S`).not_to be_empty
+    collector_pid = File.read(collector_pid_location)
+
+    # Give time for the monitor interval to run.
+    sleep 30
+
+    expect(`pgrep otelcol-contrib --runstates D,R,S`).not_to be_empty
+    second_read_pid = File.read(collector_pid_location)
+
+    expect(second_read_pid).to eq(collector_pid)
+  end
+end


### PR DESCRIPTION
Fixes an issue with state file sha checking, where it wasn't updating the SHA on mismatch, nor setting it correctly on initiation. This causes the collector to exit and restart every healthcheck interval.