### PR TITLE
Add additional values to log formatter

### DIFF
--- a/lib/scout_apm/logging/loggers/formatter.rb
+++ b/lib/scout_apm/logging/loggers/formatter.rb
@@ -49,7 +49,7 @@ module ScoutApm
           derived_key = "#{layer.type.downcase}_entrypoint".to_sym
           derived_value_of_scout_name = "#{name.capitalize}#{layer.type.capitalize}##{action.capitalize}"
 
-          { dervied_key => dervied_value_of_scout_name }
+          { derived_key => derived_value_of_scout_name }
         end
 
         def scout_context

--- a/lib/scout_apm/logging/loggers/formatter.rb
+++ b/lib/scout_apm/logging/loggers/formatter.rb
@@ -46,6 +46,8 @@ module ScoutApm
 
           name, action = layer.name.split('/')
 
+          return {} unless name && action
+
           derived_key = "#{layer.type.downcase}_entrypoint".to_sym
           derived_value_of_scout_name = "#{name.capitalize}#{layer.type.capitalize}##{action.capitalize}"
 

--- a/lib/scout_apm/logging/loggers/formatter.rb
+++ b/lib/scout_apm/logging/loggers/formatter.rb
@@ -38,7 +38,7 @@ module ScoutApm
           time.utc.strftime(DATETIME_FORMAT)
         end
 
-        def scout_layer
+        def scout_layer # rubocop:disable Metrics/AbcSize
           req = ScoutApm::RequestManager.lookup
           layer = req.instance_variable_get('@layers').find { |lay| lay.type == 'Controller' || lay.type == 'Job' }
 
@@ -48,8 +48,10 @@ module ScoutApm
 
           return {} unless name && action
 
+          updated_name = name.split('_').map(&:capitalize).join
+
           derived_key = "#{layer.type.downcase}_entrypoint".to_sym
-          derived_value_of_scout_name = "#{name.capitalize}#{layer.type.capitalize}##{action.capitalize}"
+          derived_value_of_scout_name = "#{updated_name}#{layer.type.capitalize}##{action.capitalize}"
 
           { derived_key => derived_value_of_scout_name }
         end

--- a/lib/scout_apm/logging/loggers/formatter.rb
+++ b/lib/scout_apm/logging/loggers/formatter.rb
@@ -3,6 +3,8 @@
 require 'json'
 require 'logger'
 
+require 'scout_apm'
+
 module ScoutApm
   module Logging
     module Loggers
@@ -14,9 +16,13 @@ module ScoutApm
           attributes_to_log[:severity] = severity
           attributes_to_log[:time] = format_datetime(time)
           attributes_to_log[:progname] = progname if progname
-          attributes_to_log[:pid] = Process.pid
+          attributes_to_log[:pid] = Process.pid.to_s
           attributes_to_log[:msg] = msg2str(msg)
           attributes_to_log['service.name'] = service_name
+
+          attributes_to_log.merge!(scout_layer)
+          # Naive local benchmarks show this takes around 200 microseconds. As such, we only apply it to WARN and above.
+          attributes_to_log.merge!(local_log_location) if ::Logger::Severity.const_get(severity) >= ::Logger::Severity::WARN
 
           "#{attributes_to_log.to_json}\n"
         end
@@ -29,6 +35,29 @@ module ScoutApm
 
         def format_datetime(time)
           time.utc.strftime(DATETIME_FORMAT)
+        end
+
+        def scout_layer
+          req = ScoutApm::RequestManager.lookup
+          layer = req.instance_variable_get('@layers').find { |lay| lay.type == 'Controller' || lay.type == 'Job' }
+
+          return {} unless layer
+
+          name, action = layer.name.split('/')
+
+          dervied_key = "#{layer.type.downcase}_entrypoint".to_sym
+          dervied_value_of_scout_name = "#{name.capitalize}#{layer.type.capitalize}##{action.capitalize}"
+
+          { dervied_key => dervied_value_of_scout_name }
+        end
+
+        def local_log_location
+          # Should give us the last local stack which called the log within just the last couple frames.
+          last_local_location = caller[0..15].find { |path| path.include?(Rails.root.to_s) }
+
+          return {} unless last_local_location
+
+          { 'log_location' => last_local_location }
         end
 
         # We may need to clean this up a bit.

--- a/lib/scout_apm/logging/loggers/formatter.rb
+++ b/lib/scout_apm/logging/loggers/formatter.rb
@@ -46,8 +46,8 @@ module ScoutApm
 
           name, action = layer.name.split('/')
 
-          dervied_key = "#{layer.type.downcase}_entrypoint".to_sym
-          dervied_value_of_scout_name = "#{name.capitalize}#{layer.type.capitalize}##{action.capitalize}"
+          derived_key = "#{layer.type.downcase}_entrypoint".to_sym
+          derived_value_of_scout_name = "#{name.capitalize}#{layer.type.capitalize}##{action.capitalize}"
 
           { dervied_key => dervied_value_of_scout_name }
         end

--- a/lib/scout_apm/logging/monitor/collector/configuration.rb
+++ b/lib/scout_apm/logging/monitor/collector/configuration.rb
@@ -91,6 +91,8 @@ module ScoutApm
                 log_statements:
                   - context: log
                     statements:
+                    # Copy original body to raw_bytes attribute.
+                    - 'set(attributes["raw_bytes"], body)'
                     # Replace the body with the log message.
                     - 'set(body, attributes["msg"])'
                     # Move service.name attribute to resource attribute.


### PR DESCRIPTION
Adds the controller or job entrypoint, which we get from the current tracked request in the Scout library, to the context of the log, as well as any added context to the request. Additionally, we also add where the log occurred if it is of WARN or higher.

This makes it easier to search for logs that come through a specific entrypoint ie controller or job. Additionally, when looking at an individual log, it's easier to understand where the log occurred (without the need for grepping the codebase), as well as the entrypoint to that log