### PR TITLE
Standardize config options

### DIFF
--- a/lib/scout_apm/logging/config.rb
+++ b/lib/scout_apm/logging/config.rb
@@ -1,5 +1,40 @@
 # frozen_string_literal: true
 
+# Valid Config Options:
+#
+# This list is complete, but some are for developers of
+# scout_apm_logging itself. See the documentation at https://scoutapm.com/docs for
+# customer-focused documentation.
+#
+# config_file - location of the scout_apm.yml configuration file
+# log_level          - log level for the internal library itself
+# log_stdout         - true or false.  If true, log to STDOUT
+# log_stderr         - true or false.  If true, log to STDERR
+# log_file_path      - either a directory or "STDOUT"
+# log_class          - the underlying class to use for logging.  Defaults to Ruby's Logger class
+# logs_monitor       - true or false.  If true, monitor logs
+# logs_monitored     - an array of log file paths to monitor. Overrides the default log destination detection
+# logs_ingest_key    - the ingest key to use for logs
+# logs_capture_level - the minimum log level to start capturing logs for
+# logs_config        - a hash of configuration options for merging into the collector's config
+# logs_reporting_endpoint - the endpoint to send logs to
+# logs_proxy_log_dir - the directory to store logs in for monitoring
+# manager_lock_file  - the location for obtaining an exclusive lock for running monitor manager
+# monitor_pid_file   - the location of the pid file for the monitor
+# monitor_state_file - the location of the state file for the monitor
+# monitor_interval   - the interval to check the collector healtcheck and for new state logs
+# monitor_interval_delay - the delay to wait before running the first monitor interval
+# collector_sending_queue_storage_dir - the directory to store queue files
+# collector_offset_storage_dir - the directory to store offset files
+# collector_pid_file - the location of the pid file for the collector
+# collector_download_dir - the directory to store downloaded collector files
+# collector_config_file - the location of the config file for the collector
+# collector_version - the version of the collector to download
+# health_check_port - the port to use for the collector health check. Default is dynamically derived based on port availability
+#
+# Any of these config settings can be set with an environment variable prefixed
+# by SCOUT_ and uppercasing the key: SCOUT_LOG_LEVEL for instance.
+
 module ScoutApm
   module Logging
     # Holds the configuration values for Scout APM Logging.
@@ -11,32 +46,32 @@ module ScoutApm
         log_stdout
         log_file_path
         log_class
-        logging_ingest_key
-        monitor_logs
+        logs_monitor
+        logs_monitored
+        logs_ingest_key
         logs_capture_level
+        logs_config
+        logs_reporting_endpoint
+        logs_proxy_log_dir
+        manager_lock_file
         monitor_pid_file
         monitor_state_file
+        monitor_interval
+        monitor_interval_delay
         collector_sending_queue_storage_dir
         collector_offset_storage_dir
         collector_pid_file
         collector_download_dir
         collector_config_file
         collector_version
-        manager_lock_file
-        monitored_logs
-        logs_reporting_endpoint
-        monitor_interval
         health_check_port
-        delay_first_healthcheck
-        logs_config
-        proxy_log_dir
       ].freeze
 
       SETTING_COERCIONS = {
-        'monitor_logs' => BooleanCoercion.new,
-        'monitored_logs' => JsonCoercion.new,
+        'logs_monitor' => BooleanCoercion.new,
+        'logs_monitored' => JsonCoercion.new,
         'monitor_interval' => IntegerCoercion.new,
-        'delay_first_healthcheck' => IntegerCoercion.new,
+        'monitor_interval_delay' => IntegerCoercion.new,
         'health_check_port' => IntegerCoercion.new
       }.freeze
 
@@ -122,7 +157,7 @@ module ScoutApm
       # State that is persisted and communicated upon by multiple processes.
       class ConfigState
         @values_to_set = {
-          'monitored_logs': [],
+          'logs_monitored': [],
           'health_check_port': nil
         }
 
@@ -188,21 +223,21 @@ module ScoutApm
       class ConfigDefaults
         DEFAULTS = {
           'log_level' => 'info',
+          'logs_monitored' => [],
+          'logs_capture_level' => 'debug',
+          'logs_reporting_endpoint' => 'https://otlp.telemetryhub.com:4317',
+          'logs_proxy_log_dir' => '/tmp/scout_apm/logs/',
+          'manager_lock_file' => '/tmp/scout_apm/monitor_lock_file.lock',
           'monitor_pid_file' => '/tmp/scout_apm/scout_apm_log_monitor.pid',
           'monitor_state_file' => '/tmp/scout_apm/scout_apm_log_monitor_state.json',
+          'monitor_interval' => 60,
+          'monitor_interval_delay' => 60,
           'collector_offset_storage_dir' => '/tmp/scout_apm/file_storage/receiver/',
           'collector_sending_queue_storage_dir' => '/tmp/scout_apm/file_storage/otc/',
           'collector_pid_file' => '/tmp/scout_apm/scout_apm_otel_collector.pid',
           'collector_download_dir' => '/tmp/scout_apm/',
           'collector_config_file' => '/tmp/scout_apm/config.yml',
-          'collector_version' => '0.102.1',
-          'manager_lock_file' => '/tmp/scout_apm/monitor_lock_file.lock',
-          'monitored_logs' => [],
-          'logs_reporting_endpoint' => 'https://otlp.telemetryhub.com:4317',
-          'monitor_interval' => 60,
-          'delay_first_healthcheck' => 60,
-          'proxy_log_dir' => '/tmp/scout_apm/logs/',
-          'logs_capture_level' => 'debug'
+          'collector_version' => '0.102.1'
         }.freeze
 
         def value(key)

--- a/lib/scout_apm/logging/loggers/logger.rb
+++ b/lib/scout_apm/logging/loggers/logger.rb
@@ -33,7 +33,7 @@ module ScoutApm
         end
 
         def determine_file_path # rubocop:disable Metrics/AbcSize
-          log_directory = context.config.value('proxy_log_dir')
+          log_directory = context.config.value('logs_proxy_log_dir')
 
           original_basename = File.basename(log_destination) if log_destination.is_a?(String)
 

--- a/lib/scout_apm/logging/loggers/swap.rb
+++ b/lib/scout_apm/logging/loggers/swap.rb
@@ -74,7 +74,7 @@ module ScoutApm
         end
 
         def create_proxy_log_dir!
-          Utils.ensure_directory_exists(context.config.value('proxy_log_dir'))
+          Utils.ensure_directory_exists(context.config.value('logs_proxy_log_dir'))
         end
       end
     end

--- a/lib/scout_apm/logging/monitor/collector/configuration.rb
+++ b/lib/scout_apm/logging/monitor/collector/configuration.rb
@@ -77,7 +77,7 @@ module ScoutApm
           <<~CONFIG
             receivers:
               filelog:
-                include: [#{context.config.value('monitored_logs').join(',')}]
+                include: [#{context.config.value('logs_monitored').join(',')}]
                 storage: file_storage/filelogreceiver
                 operators:
                   - type: json_parser
@@ -102,7 +102,7 @@ module ScoutApm
               otlp:
                 endpoint: #{context.config.value('logs_reporting_endpoint')}
                 headers:
-                  x-telemetryhub-key: #{context.config.value('logging_ingest_key')}
+                  x-telemetryhub-key: #{context.config.value('logs_ingest_key')}
                 sending_queue:
                   storage: file_storage/otc
             extensions:

--- a/lib/scout_apm/logging/monitor/monitor.rb
+++ b/lib/scout_apm/logging/monitor/monitor.rb
@@ -44,7 +44,7 @@ module ScoutApm
         add_exit_handler!
 
         unless has_logs_to_monitor?
-          context.config.logger.warn('No logs are set to be monitored. Please set the `monitored_logs` config setting. Exiting.')
+          context.config.logger.warn('No logs are set to be monitored. Please set the `logs_monitored` config setting. Exiting.')
           return
         end
 
@@ -58,7 +58,7 @@ module ScoutApm
       def run!
         # Prevent the monitor from checking the collector health before it's fully started.
         # Having this be configurable is useful for testing.
-        sleep context.config.value('delay_first_healthcheck')
+        sleep context.config.value('monitor_interval_delay')
 
         loop do
           sleep context.config.value('monitor_interval')
@@ -87,7 +87,7 @@ module ScoutApm
       end
 
       def has_logs_to_monitor?
-        context.config.value('monitored_logs').any?
+        context.config.value('logs_monitored').any?
       end
 
       def has_previous_collector_setup?

--- a/lib/scout_apm/logging/monitor_manager/manager.rb
+++ b/lib/scout_apm/logging/monitor_manager/manager.rb
@@ -30,7 +30,7 @@ module ScoutApm
       end
 
       def determine_configuration_state
-        monitoring_enabled = context.config.value('monitor_logs')
+        monitoring_enabled = context.config.value('logs_monitor')
 
         if monitoring_enabled
           context.logger.info('Log monitoring enabled')

--- a/lib/scout_apm/logging/state.rb
+++ b/lib/scout_apm/logging/state.rb
@@ -35,10 +35,10 @@ module ScoutApm
                                  []
                                else
                                  current_data = JSON.parse(contents)
-                                 current_data['monitored_logs']
+                                 current_data['logs_monitored']
                                end
 
-              data['monitored_logs'] = merge_and_dedup_log_locations(updated_log_locations, olds_log_files)
+              data['logs_monitored'] = merge_and_dedup_log_locations(updated_log_locations, olds_log_files)
             end
 
             file.rewind # Move cursor to beginning of the file

--- a/spec/data/config_test_1.yml
+++ b/spec/data/config_test_1.yml
@@ -7,9 +7,9 @@ common: &defaults
   ###
   # Logging
   ###
-  monitor_logs: true
-  logging_ingest_key: "00001000010000abc"
-  monitored_logs: ["/tmp/fake_log_file.log"]
+  logs_monitor: true
+  logs_ingest_key: "00001000010000abc"
+  logs_monitored: ["/tmp/fake_log_file.log"]
 
 production:
   <<: *defaults

--- a/spec/data/mock_config.yml
+++ b/spec/data/mock_config.yml
@@ -7,9 +7,9 @@ common: &defaults
   ###
   # Logging
   ###
-  monitor_logs: true
-  logging_ingest_key: "00001000010000abc"
-  monitored_logs: ["/tmp/fake_log_file.log"]
+  logs_monitor: true
+  logs_ingest_key: "00001000010000abc"
+  logs_monitored: ["/tmp/fake_log_file.log"]
   # Need to give a high enough number for the original health check to pass
   monitor_interval: 10
 

--- a/spec/integration/loggers/capture_spec.rb
+++ b/spec/integration/loggers/capture_spec.rb
@@ -5,8 +5,8 @@ require 'spec_helper'
 describe ScoutApm::Logging::Loggers::Capture do
   it 'should find the logger, capture the log destination, and rotate collector configs' do
     ENV['SCOUT_MONITOR_INTERVAL'] = '10'
-    ENV['SCOUT_DELAY_FIRST_HEALTHCHECK'] = '10'
-    ENV['SCOUT_MONITOR_LOGS'] = 'true'
+    ENV['SCOUT_MONITOR_INTERVAL_DELAY'] = '10'
+    ENV['SCOUT_LOGS_MONITOR'] = 'true'
 
     context = ScoutApm::Logging::MonitorManager.instance.context
 
@@ -16,7 +16,7 @@ describe ScoutApm::Logging::Loggers::Capture do
 
     first_logger = ScoutTestLogger.new('/tmp/first_file.log')
     first_logger_basename = File.basename(first_logger.instance_variable_get(:@logdev).filename.to_s)
-    first_logger_updated_path = File.join(context.config.value('proxy_log_dir'), first_logger_basename)
+    first_logger_updated_path = File.join(context.config.value('logs_proxy_log_dir'), first_logger_basename)
 
     # While we only use the ObjectSpace for the test logger, we need to wait for it to be captured.
     wait_for_logger
@@ -31,18 +31,18 @@ describe ScoutApm::Logging::Loggers::Capture do
 
     content = File.read(state_file_location)
     data = JSON.parse(content)
-    expect(data['monitored_logs']).to eq([first_logger_updated_path])
+    expect(data['logs_monitored']).to eq([first_logger_updated_path])
 
     second_logger = ScoutTestLogger.new('/tmp/second_file.log')
     second_logger_basename = File.basename(second_logger.instance_variable_get(:@logdev).filename.to_s)
-    second_logger_updated_path = File.join(context.config.value('proxy_log_dir'), second_logger_basename)
+    second_logger_updated_path = File.join(context.config.value('logs_proxy_log_dir'), second_logger_basename)
 
     similuate_railtie
 
     content = File.read(state_file_location)
     data = JSON.parse(content)
 
-    expect(data['monitored_logs'].sort).to eq([first_logger_updated_path, second_logger_updated_path])
+    expect(data['logs_monitored'].sort).to eq([first_logger_updated_path, second_logger_updated_path])
 
     # Need to wait for the delay first health check, next monitor interval to restart the collector, and then for
     # the collector to restart

--- a/spec/integration/monitor/collector/downloader/will_verify_checksum.rb
+++ b/spec/integration/monitor/collector/downloader/will_verify_checksum.rb
@@ -4,8 +4,8 @@ require_relative '../../../../../lib/scout_apm/logging/monitor/collector/downloa
 
 describe ScoutApm::Logging::Collector::Downloader do
   it 'should validate checksum, and correct download if neccessary' do
-    ENV['SCOUT_MONITOR_LOGS'] = 'true'
-    ENV['SCOUT_MONITORED_LOGS'] = '["/tmp/test.log"]'
+    ENV['SCOUT_LOGS_MONITOR'] = 'true'
+    ENV['SCOUT_LOGS_MONITORED'] = '["/tmp/test.log"]'
 
     otelcol_contrib_path = '/tmp/scout_apm/otelcol-contrib'
     ScoutApm::Logging::Utils.ensure_directory_exists(otelcol_contrib_path)
@@ -21,7 +21,7 @@ describe ScoutApm::Logging::Collector::Downloader do
 
     expect(`pgrep otelcol-contrib --runstates D,R,S`).not_to be_empty
 
-    ENV['SCOUT_MONITOR_LOGS'] = 'false'
+    ENV['SCOUT_LOGS_MONITOR'] = 'false'
 
     ScoutApm::Logging::MonitorManager.new.setup!
 
@@ -31,7 +31,7 @@ describe ScoutApm::Logging::Collector::Downloader do
     expect(`pgrep otelcol-contrib --runstates D,R,S`).to be_empty
     expect(`pgrep scout_apm_log_monitor --runstates D,R,S`).to be_empty
 
-    ENV['SCOUT_MONITOR_LOGS'] = 'true'
+    ENV['SCOUT_LOGS_MONITOR'] = 'true'
 
     ScoutApm::Logging::MonitorManager.new.setup!
 

--- a/spec/integration/monitor/collector_healthcheck_spec.rb
+++ b/spec/integration/monitor/collector_healthcheck_spec.rb
@@ -5,9 +5,9 @@ require_relative '../../../lib/scout_apm/logging/monitor/monitor'
 describe ScoutApm::Logging::Monitor do
   it 'should recreate collector process on healthcheck if it has exited' do
     ENV['SCOUT_MONITOR_INTERVAL'] = '10'
-    ENV['SCOUT_DELAY_FIRST_HEALTHCHECK'] = '10'
-    ENV['SCOUT_MONITOR_LOGS'] = 'true'
-    ENV['SCOUT_MONITORED_LOGS'] = '["/tmp/test.log"]'
+    ENV['SCOUT_MONITOR_INTERVAL_DELAY'] = '10'
+    ENV['SCOUT_LOGS_MONITOR'] = 'true'
+    ENV['SCOUT_LOGS_MONITORED'] = '["/tmp/test.log"]'
 
     ScoutApm::Logging::Utils.ensure_directory_exists('/tmp/scout_apm/scout_apm_log_monitor.pid')
 

--- a/spec/integration/monitor/continuous_state_collector_spec.rb
+++ b/spec/integration/monitor/continuous_state_collector_spec.rb
@@ -5,9 +5,9 @@ require_relative '../../../lib/scout_apm/logging/monitor/monitor'
 describe ScoutApm::Logging::Monitor do
   it "Should not restart the collector if the state hasn't changed" do
     ENV['SCOUT_MONITOR_INTERVAL'] = '10'
-    ENV['SCOUT_DELAY_FIRST_HEALTHCHECK'] = '10'
-    ENV['SCOUT_MONITOR_LOGS'] = 'true'
-    ENV['SCOUT_MONITORED_LOGS'] = '["/tmp/test.log"]'
+    ENV['SCOUT_MONITOR_INTERVAL_DELAY'] = '10'
+    ENV['SCOUT_LOGS_MONITOR'] = 'true'
+    ENV['SCOUT_LOGS_MONITORED'] = '["/tmp/test.log"]'
 
     context = ScoutApm::Logging::MonitorManager.instance.context
     collector_pid_location = context.config.value('collector_pid_file')

--- a/spec/integration/monitor/previous_collector_setup_spec.rb
+++ b/spec/integration/monitor/previous_collector_setup_spec.rb
@@ -4,8 +4,8 @@ require_relative '../../../lib/scout_apm/logging/monitor/monitor'
 
 describe ScoutApm::Logging::Monitor do
   it 'should use previous collector setup if monitor daemon exits' do
-    ENV['SCOUT_MONITOR_LOGS'] = 'true'
-    ENV['SCOUT_MONITORED_LOGS'] = '["/tmp/test.log"]'
+    ENV['SCOUT_LOGS_MONITOR'] = 'true'
+    ENV['SCOUT_LOGS_MONITORED'] = '["/tmp/test.log"]'
 
     monitor_pid_location = ScoutApm::Logging::MonitorManager.instance.context.config.value('monitor_pid_file')
     collector_pid_location = ScoutApm::Logging::MonitorManager.instance.context.config.value('collector_pid_file')

--- a/spec/integration/monitor_manager/disable_agent_spec.rb
+++ b/spec/integration/monitor_manager/disable_agent_spec.rb
@@ -4,8 +4,8 @@ require_relative '../../../lib/scout_apm/logging/monitor/collector/manager'
 
 describe ScoutApm::Logging::Collector::Manager do
   it 'If monitor is false, it should remove the daemon and collector process if they are present' do
-    ENV['SCOUT_MONITOR_LOGS'] = 'true'
-    ENV['SCOUT_MONITORED_LOGS'] = '["/tmp/test.log"]'
+    ENV['SCOUT_LOGS_MONITOR'] = 'true'
+    ENV['SCOUT_LOGS_MONITORED'] = '["/tmp/test.log"]'
 
     expect(`pgrep otelcol-contrib --runstates D,R,S`).to be_empty
 
@@ -13,7 +13,7 @@ describe ScoutApm::Logging::Collector::Manager do
 
     wait_for_process_with_timeout!('otelcol-contrib', 20)
 
-    ENV['SCOUT_MONITOR_LOGS'] = 'false'
+    ENV['SCOUT_LOGS_MONITOR'] = 'false'
 
     ScoutApm::Logging::MonitorManager.new.setup!
 
@@ -23,6 +23,6 @@ describe ScoutApm::Logging::Collector::Manager do
     expect(`pgrep otelcol-contrib --runstates D,R,S`).to be_empty
     expect(`pgrep scout_apm_log_monitor --runstates D,R,S`).to be_empty
 
-    ENV.delete('SCOUT_MONITOR_LOGS')
+    ENV.delete('SCOUT_LOGS_MONITOR')
   end
 end

--- a/spec/integration/monitor_manager/monitor_pid_file_spec.rb
+++ b/spec/integration/monitor_manager/monitor_pid_file_spec.rb
@@ -4,8 +4,8 @@ require_relative '../../../lib/scout_apm/logging/monitor/collector/manager'
 
 describe ScoutApm::Logging::Collector::Manager do
   it 'should recreate the monitor process if monitor.pid file is errant' do
-    ENV['SCOUT_MONITOR_LOGS'] = 'true'
-    ENV['SCOUT_MONITORED_LOGS'] = '["/tmp/test.log"]'
+    ENV['SCOUT_LOGS_MONITOR'] = 'true'
+    ENV['SCOUT_LOGS_MONITORED'] = '["/tmp/test.log"]'
 
     ScoutApm::Logging::Utils.ensure_directory_exists('/tmp/scout_apm/scout_apm_log_monitor.pid')
 
@@ -26,7 +26,7 @@ describe ScoutApm::Logging::Collector::Manager do
 
     # Check if the process with the stored PID is running
     expect(Process.kill(0, new_pid)).to be_truthy
-    ENV.delete('SCOUT_MONITOR_LOGS')
+    ENV.delete('SCOUT_LOGS_MONITOR')
 
     # Kill the process and ensure PID file clean up
     Process.kill('TERM', new_pid)

--- a/spec/integration/monitor_manager/single_monitor_spec.rb
+++ b/spec/integration/monitor_manager/single_monitor_spec.rb
@@ -9,8 +9,8 @@ require 'spec_helper'
 
 describe ScoutApm::Logging do
   it 'Should only create a single monitor daemon if manager is called multiple times' do
-    ENV['SCOUT_MONITOR_LOGS'] = 'true'
-    ENV['SCOUT_MONITORED_LOGS'] = '["/tmp/test.log"]'
+    ENV['SCOUT_LOGS_MONITOR'] = 'true'
+    ENV['SCOUT_LOGS_MONITORED'] = '["/tmp/test.log"]'
 
     pid_file = ScoutApm::Logging::MonitorManager.instance.context.config.value('monitor_pid_file')
     expect(File.exist?(pid_file)).to be_falsey

--- a/spec/integration/rails/lifecycle_spec.rb
+++ b/spec/integration/rails/lifecycle_spec.rb
@@ -2,8 +2,8 @@ require 'spec_helper'
 
 describe ScoutApm::Logging do
   it 'checks the Rails lifecycle for creating the daemon and collector processes' do
-    ENV['SCOUT_MONITOR_LOGS'] = 'true'
-    ENV['SCOUT_MONITORED_LOGS'] = '["/tmp/test.log"]'
+    ENV['SCOUT_LOGS_MONITOR'] = 'true'
+    ENV['SCOUT_LOGS_MONITORED'] = '["/tmp/test.log"]'
 
     pid_file = ScoutApm::Logging::MonitorManager.instance.context.config.value('monitor_pid_file')
     expect(File.exist?(pid_file)).to be_falsey

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -7,10 +7,10 @@ describe ScoutApm::Logging::Config do
     conf = ScoutApm::Logging::Config.with_file(context, conf_file)
 
     expect(conf.value('log_level')).to eq('debug')
-    expect(conf.value('monitor_logs')).to eq(true)
+    expect(conf.value('logs_monitor')).to eq(true)
     expect(conf.value('monitor_pid_file')).to eq('/tmp/scout_apm/scout_apm_log_monitor.pid')
-    expect(conf.value('logging_ingest_key')).to eq('00001000010000abc')
-    expect(conf.value('monitored_logs')).to eq(['/tmp/fake_log_file.log'])
+    expect(conf.value('logs_ingest_key')).to eq('00001000010000abc')
+    expect(conf.value('logs_monitored')).to eq(['/tmp/fake_log_file.log'])
   end
 
   it 'loads the state file into the config' do

--- a/spec/unit/loggers/capture_spec.rb
+++ b/spec/unit/loggers/capture_spec.rb
@@ -17,8 +17,8 @@ end
 describe ScoutApm::Logging::Loggers::Capture do
   it 'should swap the STDOUT logger and create a proxy logger' do
     ENV['SCOUT_MONITOR_INTERVAL'] = '10'
-    ENV['SCOUT_DELAY_FIRST_HEALTHCHECK'] = '10'
-    ENV['SCOUT_MONITOR_LOGS'] = 'true'
+    ENV['SCOUT_MONITOR_INTERVAL_DELAY'] = '10'
+    ENV['SCOUT_LOGS_MONITOR'] = 'true'
 
     output_from_log = capture_stdout do
       context = ScoutApm::Logging::Context.new
@@ -33,13 +33,13 @@ describe ScoutApm::Logging::Loggers::Capture do
 
       TestLoggerWrapper.logger.info('TEST')
 
-      log_path = File.join(context.config.value('proxy_log_dir'), 'test.log')
+      log_path = File.join(context.config.value('logs_proxy_log_dir'), 'test.log')
       content = File.read(log_path)
       expect(content).to include('TEST')
 
       state_file = File.read(context.config.value('monitor_state_file'))
       state_data = JSON.parse(state_file)
-      expect(state_data['monitored_logs']).to eq([log_path])
+      expect(state_data['logs_monitored']).to eq([log_path])
     end
 
     expect(output_from_log).to include('TEST')

--- a/spec/unit/state_spec.rb
+++ b/spec/unit/state_spec.rb
@@ -15,6 +15,6 @@ describe ScoutApm::Logging::Config do
     data = ScoutApm::Logging::Config::State.new(context).load_state_from_file
 
     expect(data['health_check_port']).to eq(context.config.value('health_check_port'))
-    expect(data['monitored_logs']).to eq(context.config.value('monitored_logs'))
+    expect(data['logs_monitored']).to eq(context.config.value('logs_monitored'))
   end
 end


### PR DESCRIPTION
Standardizes the config options, and changes names to more accurately separate `scout_apm` config values and those from `scout_apm_logging`. Some config values are shared, such as `log_level` and `config_file`.

Adds documentation around these.