### PR TITLE
Prevent monitor removal when worker processes exit

### DIFF
--- a/lib/scout_apm/logging/monitor/monitor.rb
+++ b/lib/scout_apm/logging/monitor/monitor.rb
@@ -29,6 +29,7 @@ module ScoutApm
 
       def initialize
         @context = Context.new
+        context.logger.debug('Monitor instance created')
 
         context.application_root = $stdin.gets&.chomp
 
@@ -83,6 +84,7 @@ module ScoutApm
         exit if fork
         $stdin.reopen '/dev/null'
 
+        context.logger.debug("Monitor process daemonized, PID: #{Process.pid}")
         File.write(context.config.value('monitor_pid_file'), Process.pid)
       end
 

--- a/lib/scout_apm/logging/monitor_manager/manager.rb
+++ b/lib/scout_apm/logging/monitor_manager/manager.rb
@@ -90,7 +90,10 @@ module ScoutApm
 
         # Naive benchmarks show this taking ~0.01 seconds.
         loop do
-          break if File.exist?(context.config.value('monitor_pid_file'))
+          if File.exist?(context.config.value('monitor_pid_file'))
+            context.logger.debug('Monitor PID file exists. Releasing lock.')
+            break
+          end
 
           if Time.now - start_time > timeout_seconds
             context.logger.warn('Unable to verify monitor PID file write. Releasing lock.')

--- a/spec/integration/monitor/collector/downloader/will_verify_checksum.rb
+++ b/spec/integration/monitor/collector/downloader/will_verify_checksum.rb
@@ -12,7 +12,9 @@ describe ScoutApm::Logging::Collector::Downloader do
 
     File.write(otelcol_contrib_path, 'fake content')
 
+    ScoutApm::Logging::MonitorManager.instance.context.logger.info "Time start: #{Time.now}"
     ScoutApm::Logging::MonitorManager.instance.setup!
+    ScoutApm::Logging::MonitorManager.instance.context.logger.info "Time after setup: #{Time.now}"
 
     # Give the process time to initialize, download the collector, and start it
     wait_for_process_with_timeout!('otelcol-contrib', 20)

--- a/spec/integration/monitor/collector_healthcheck_spec.rb
+++ b/spec/integration/monitor/collector_healthcheck_spec.rb
@@ -11,7 +11,9 @@ describe ScoutApm::Logging::Monitor do
 
     ScoutApm::Logging::Utils.ensure_directory_exists('/tmp/scout_apm/scout_apm_log_monitor.pid')
 
+    ScoutApm::Logging::MonitorManager.instance.context.logger.info "Time start: #{Time.now}"
     ScoutApm::Logging::MonitorManager.instance.setup!
+    ScoutApm::Logging::MonitorManager.instance.context.logger.info "Time after setup: #{Time.now}"
 
     # Give the process time to initialize, download the collector, and start it
     wait_for_process_with_timeout!('otelcol-contrib', 20)

--- a/spec/integration/monitor/continuous_state_collector_spec.rb
+++ b/spec/integration/monitor/continuous_state_collector_spec.rb
@@ -11,7 +11,9 @@ describe ScoutApm::Logging::Monitor do
 
     context = ScoutApm::Logging::MonitorManager.instance.context
     collector_pid_location = context.config.value('collector_pid_file')
+    ScoutApm::Logging::MonitorManager.instance.context.logger.info "Time start: #{Time.now}"
     ScoutApm::Logging::MonitorManager.instance.setup!
+    ScoutApm::Logging::MonitorManager.instance.context.logger.info "Time after setup: #{Time.now}"
     # Give the process time to initialize, download the collector, and start it
     wait_for_process_with_timeout!('otelcol-contrib', 20)
 

--- a/spec/integration/monitor/previous_collector_setup_spec.rb
+++ b/spec/integration/monitor/previous_collector_setup_spec.rb
@@ -11,7 +11,10 @@ describe ScoutApm::Logging::Monitor do
     collector_pid_location = ScoutApm::Logging::MonitorManager.instance.context.config.value('collector_pid_file')
     ScoutApm::Logging::Utils.ensure_directory_exists(monitor_pid_location)
 
+    ScoutApm::Logging::MonitorManager.instance.context.logger.info "Time start: #{Time.now}"
     ScoutApm::Logging::MonitorManager.instance.setup!
+    ScoutApm::Logging::MonitorManager.instance.context.logger.info "Time after setup: #{Time.now}"
+
     # Give the process time to initialize, download the collector, and start it
     wait_for_process_with_timeout!('otelcol-contrib', 20)
 

--- a/spec/integration/monitor_manager/disable_agent_spec.rb
+++ b/spec/integration/monitor_manager/disable_agent_spec.rb
@@ -9,7 +9,9 @@ describe ScoutApm::Logging::Collector::Manager do
 
     expect(`pgrep otelcol-contrib --runstates D,R,S`).to be_empty
 
+    ScoutApm::Logging::MonitorManager.instance.context.logger.info "Time start: #{Time.now}"
     ScoutApm::Logging::MonitorManager.instance.setup!
+    ScoutApm::Logging::MonitorManager.instance.context.logger.info "Time after setup: #{Time.now}"
 
     wait_for_process_with_timeout!('otelcol-contrib', 20)
 

--- a/spec/integration/monitor_manager/monitor_pid_file_spec.rb
+++ b/spec/integration/monitor_manager/monitor_pid_file_spec.rb
@@ -15,7 +15,9 @@ describe ScoutApm::Logging::Collector::Manager do
       file.write('123456')
     end
 
+    ScoutApm::Logging::MonitorManager.instance.context.logger.info "Time start: #{Time.now}"
     ScoutApm::Logging::MonitorManager.instance.setup!
+    ScoutApm::Logging::MonitorManager.instance.context.logger.info "Time after setup: #{Time.now}"
 
     # Give the process time to initialize, download the collector, and start it
     wait_for_process_with_timeout!('otelcol-contrib', 20)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,6 +21,7 @@ class ScoutTestLogger < ::Logger
 end
 
 RSpec.configure do |config|
+  ENV["SCOUT_LOG_FILE_PATH"] = "STDOUT"
   ENV["SCOUT_LOG_LEVEL"] = "debug"
   ENV["SCOUT_COLLECTOR_LOG_LEVEL"] = "info"
 


### PR DESCRIPTION
This prevent the removal of the monitor and collector processes when a worker exits, which can be through the likes of unicorn or puma worker killer. We only want to remove (then restart) the processes when the entire Rails app exists.