### PR TITLE
Fix memoization of log attributes

### DIFF
--- a/lib/scout_apm/logging/loggers/formatter.rb
+++ b/lib/scout_apm/logging/loggers/formatter.rb
@@ -12,12 +12,15 @@ module ScoutApm
       class Formatter < ::Logger::Formatter
         DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%S.%LZ'
 
-        def call(severity, time, progname, msg) # rubocop:disable Metrics/AbcSize
-          attributes_to_log[:severity] = severity
-          attributes_to_log[:time] = format_datetime(time)
+        def call(severity, time, progname, msg)
+          attributes_to_log = {
+            severity: severity,
+            time: format_datetime(time),
+            pid: Process.pid.to_s,
+            msg: msg2str(msg)
+          }
+
           attributes_to_log[:progname] = progname if progname
-          attributes_to_log[:pid] = Process.pid.to_s
-          attributes_to_log[:msg] = msg2str(msg)
           attributes_to_log['service.name'] = service_name
 
           attributes_to_log.merge!(scout_layer)
@@ -29,10 +32,6 @@ module ScoutApm
         end
 
         private
-
-        def attributes_to_log
-          @attributes_to_log ||= {}
-        end
 
         def format_datetime(time)
           time.utc.strftime(DATETIME_FORMAT)

--- a/spec/integration/rails/lifecycle_spec.rb
+++ b/spec/integration/rails/lifecycle_spec.rb
@@ -48,6 +48,11 @@ describe ScoutApm::Logging do
     expect(messages.count('[YIELD] Yield Test')).to eq(1)
     expect(messages.count('Another Log')).to eq(1)
 
+    log_locations = lines.map { |item| item['log_location'] }.compact
+
+    # Verify that log attributes aren't persisted
+    expect(log_locations.size).to eq(1)
+
     # Kill the rails process. We use kill as using any other signal throws a long log line.
     Process.kill('KILL', rails_pid)
     # Kill the process and ensure PID file clean up

--- a/spec/rails/app.rb
+++ b/spec/rails/app.rb
@@ -20,6 +20,7 @@ end
 
 class RootController < ActionController::Base
   def index
+    Rails.logger.warn('Add location log attributes')
     Rails.logger.tagged('TEST').info('Some log')
     Rails.logger.tagged('YIELD') { logger.info('Yield Test') }
     Rails.logger.info('Another Log')


### PR DESCRIPTION
Removes memoization of log attributes. This would cause issues, as it could/would lead to persistent attributes in threaded services.