### PR TITLE
Set logging level back on original logger

### DIFF
--- a/lib/scout_apm/logging/loggers/swaps/rails.rb
+++ b/lib/scout_apm/logging/loggers/swaps/rails.rb
@@ -46,6 +46,7 @@ module ScoutApm
             original_logdevice = log_instance.instance_variable_get(:@logdev)
 
             ::Logger.new(original_logdevice).tap do |logger|
+              logger.level = log_instance.level
               logger.formatter = log_instance.formatter
             end
           end

--- a/lib/scout_apm/logging/loggers/swaps/scout.rb
+++ b/lib/scout_apm/logging/loggers/swaps/scout.rb
@@ -41,6 +41,7 @@ module ScoutApm
             original_logdevice = log_instance.instance_variable_get(:@logdev)
 
             ::Logger.new(original_logdevice).tap do |logger|
+              logger.level = log_instance.level
               logger.formatter = log_instance.formatter
             end
           end

--- a/lib/scout_apm/logging/loggers/swaps/sidekiq.rb
+++ b/lib/scout_apm/logging/loggers/swaps/sidekiq.rb
@@ -41,6 +41,7 @@ module ScoutApm
             original_logdevice = log_instance.instance_variable_get(:@logdev)
 
             ::Logger.new(original_logdevice).tap do |logger|
+              logger.level = log_instance.level
               logger.formatter = log_instance.formatter
             end
           end

--- a/spec/integration/rails/lifecycle_spec.rb
+++ b/spec/integration/rails/lifecycle_spec.rb
@@ -47,6 +47,7 @@ describe ScoutApm::Logging do
     expect(messages.count('[TEST] Some log')).to eq(1)
     expect(messages.count('[YIELD] Yield Test')).to eq(1)
     expect(messages.count('Another Log')).to eq(1)
+    expect(messages.count('Should not be captured')).to eq(0)
 
     log_locations = lines.map { |item| item['log_location'] }.compact
 

--- a/spec/rails/app.rb
+++ b/spec/rails/app.rb
@@ -12,6 +12,7 @@ Rails.logger = ActiveSupport::TaggedLogging.new(Logger.new($stdout))
 
 class App < ::Rails::Application
   config.eager_load = false
+  config.log_level = :info
 
   routes.append do
     root to: 'root#index'
@@ -24,6 +25,8 @@ class RootController < ActionController::Base
     Rails.logger.tagged('TEST').info('Some log')
     Rails.logger.tagged('YIELD') { logger.info('Yield Test') }
     Rails.logger.info('Another Log')
+    Rails.logger.debug('Should not be captured')
+
     render plain: Rails.version
   end
 end


### PR DESCRIPTION
Fixes a potential issue where the original level was not being placed back on to the original logger, and would be set to debug