### PR TITLE
Re-broadcast to console in development

### DIFF
--- a/lib/scout_apm/logging/loggers/logger.rb
+++ b/lib/scout_apm/logging/loggers/logger.rb
@@ -3,7 +3,9 @@
 module ScoutApm
   module Logging
     module Loggers
+      # The actual instance of the logger.
       class FileLogger < ::Logger
+        include ::ActiveSupport::LoggerSilence if const_defined?('::ActiveSupport::LoggerSilence')
       end
 
       # The newly created logger which we can configure, and will log to a filepath.


### PR DESCRIPTION
If we are in development, and not running in a daemon, re-broadcast to the console from the filelogger. This only applies to non broadcast loggers and reimplements the following:
https://github.com/rails/rails/blob/v6.1.7.8/railties/lib/rails/commands/server/server_command.rb#L76-L86