### PR TITLE
Add support for Rails env in Scout config file

### DIFF
--- a/bin/scout_apm_logging_monitor
+++ b/bin/scout_apm_logging_monitor
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 
+require_relative '../lib/scout_apm/logging/monitor/_rails.rb'
 require_relative "../lib/scout_apm/logging/monitor/monitor.rb"
 
 ScoutApm::Logging::Monitor.instance.setup!

--- a/lib/scout_apm/logging/loggers/swaps/rails.rb
+++ b/lib/scout_apm/logging/loggers/swaps/rails.rb
@@ -50,11 +50,11 @@ module ScoutApm
               logger.formatter = log_instance.formatter
 
               if ::Rails.env.development? && $stdout.tty? && $stderr.tty?
-                next if ActiveSupport::Logger.respond_to?(:logger_outputs_to?) && ActiveSupport::Logger.logger_outputs_to?(
+                next if ::ActiveSupport::Logger.respond_to?(:logger_outputs_to?) && ::ActiveSupport::Logger.logger_outputs_to?(
                   logger, $stdout, $stderr
                 )
 
-                logger.extend(ActiveSupport::Logger.broadcast(ActiveSupport::Logger.new($stdout)))
+                logger.extend(ActiveSupport::Logger.broadcast(::ActiveSupport::Logger.new($stdout)))
               end
             end
           end

--- a/lib/scout_apm/logging/monitor/_rails.rb
+++ b/lib/scout_apm/logging/monitor/_rails.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# We start the monitor process outside the context of Rails, and ultimately don't use
+# it for anything related to starting the collector. However, when we load the config/scout_apm.yml file,
+# we support ERB, and users may be using Rails.env methods for naming the app, or configuring whether
+# monitor should be enabled for a specific environment.
+
+require 'active_support'
+
+# https://github.com/rails/rails/blob/v7.2.1/railties/lib/rails.rb#L76
+module Rails
+  class << self
+    def env
+      # EnvironmentInquirer was added in Rails 6.1
+      @env ||= if const_defined?('::ActiveSupport::EnvironmentInquirer')
+                 ::ActiveSupport::EnvironmentInquirer.new(ENV['RAILS_ENV'].presence || ENV['RACK_ENV'].presence || 'development')
+               else
+                 ::ActiveSupport::StringInquirer.new(ENV['RAILS_ENV'].presence || ENV['RACK_ENV'].presence || 'development')
+               end
+    end
+  end
+end


### PR DESCRIPTION
Fixes an issue where customers who were utilizing ERB evaluation in their config/scout_apm.yml would get an error when utilizing Rails.env. As the monitor process doesn't start within the context of Rails, and doesn't require it for managing or starting the collector, `Rails` wouldn't be defined, and users would not have their config file loaded and would be met with:

```
[Scout] [08/28/24 13:07:08 -0600  (95140)] INFO : Failed loading configuration file (/config/scout_apm.yml): ScoutAPM will continue starting with configuration from ENV and defaults. Exception was NameError: uninitialized constant ScoutApm::Config::ConfigFile::Rails
  (erb):10:in `load_file'
 .rvm/rubies/ruby-2.6.5/lib/ruby/2.6.0/erb.rb:901:in `eval'
 .rvm/rubies/ruby-2.6.5/lib/ruby/2.6.0/erb.rb:901:in `result'
 .rvm/gems/ruby-2.6.5/gems/scout_apm-5.3.8/lib/scout_apm/config.rb:449:in `load_file'
 .rvm/gems/ruby-2.6.5/gems/scout_apm-5.3.8/lib/scout_apm/config.rb:403:in `initialize'
 .rvm/gems/ruby-2.6.5/gems/scout_apm_logging-0.0.11/lib/scout_apm/logging/config.rb:97:in `new'
 .rvm/gems/ruby-2.6.5/gems/scout_apm_logging-0.0.11/lib/scout_apm/logging/config.rb:97:in `with_file'
 .rvm/gems/ruby-2.6.5/gems/scout_apm_logging-0.0.11/lib/scout_apm/logging/monitor/monitor.rb:37:in `initialize'
 .rvm/gems/ruby-2.6.5/gems/scout_apm_logging-0.0.11/lib/scout_apm/logging/monitor/monitor.rb:27:in `new'
 .rvm/gems/ruby-2.6.5/gems/scout_apm_logging-0.0.11/lib/scout_apm/logging/monitor/monitor.rb:27:in `instance'
 .rvm/gems/ruby-2.6.5/gems/scout_apm_logging-0.0.11/bin/scout_apm_logging_monitor:5:in `<main>'
```