### PR TITLE
Prevent setting of certain attributes on created logger

### DIFF
--- a/lib/scout_apm/logging/loggers/proxy.rb
+++ b/lib/scout_apm/logging/loggers/proxy.rb
@@ -27,6 +27,17 @@ module ScoutApm
           @loggers
         end
 
+        # We don't want other libraries to change the formatter of the logger we create.
+        def formatter=(formatter)
+          @loggers.first.formatter = formatter
+        end
+
+        # We don't want other libraries to change the level of the logger we create, as this
+        # is dictated by the logs_capture_level configuration.
+        def level=(level)
+          @loggers.first.level = level
+        end
+
         def class
           ::Logger
         end


### PR DESCRIPTION
This PR prevents other libraries that are initializing after ours from overwriting certain attributes (specifically formatter and level) we have set on the logger we create. 

This will still allow other libraries to change these attributes on the original logger.