### PR TITLE
Draft: Capture after initialization

### DIFF
--- a/lib/scout_apm_logging.rb
+++ b/lib/scout_apm_logging.rb
@@ -19,13 +19,15 @@ module ScoutApm
       # If we are in a Rails environment, setup the monitor daemon manager.
       class RailTie < ::Rails::Railtie
         initializer 'scout_apm_logging.monitor' do
-          context = ScoutApm::Logging::MonitorManager.instance.context
+          ::Rails.application.config.after_initialize do
+            context = ScoutApm::Logging::MonitorManager.instance.context
 
-          Loggers::Capture.new(context).setup!
+            Loggers::Capture.new(context).setup!
 
-          unless Utils.skip_setup?
-            Utils.attempt_exclusive_lock(context) do
-              ScoutApm::Logging::MonitorManager.instance.setup!
+            unless Utils.skip_setup?
+              Utils.attempt_exclusive_lock(context) do
+                ScoutApm::Logging::MonitorManager.instance.setup!
+              end
             end
           end
         end


### PR DESCRIPTION
More of a test. This does cause us to miss other logs that are occurring during initializations, but prevents other libraries from overwriting us. Unless they too are doing this after_initialize. We may want to be a bit more aggressive, and patch `Rails.logger=` from updating the logger and instead adding it to / updating the proxy.