### PR TITLE
Handle Rails logger setting

### DIFF
--- a/lib/scout_apm/logging/loggers/patches/rails_logger.rb
+++ b/lib/scout_apm/logging/loggers/patches/rails_logger.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# A patch to Rails to allow swapping out the logger for the held logger in the proxy.
+module Rails
+  class << self
+    def logger=(new_logger)
+      @logger.tap do |rails_logger|
+        if rails_logger.respond_to?(:is_scout_proxy_logger?)
+          old_logger = rails_logger.instance_variable_get(:@loggers).first
+          rails_logger.swap_scout_loggers!(old_logger, new_logger)
+        else
+          @logger = new_logger
+        end
+      end
+    end
+  end
+end

--- a/lib/scout_apm/logging/loggers/proxy.rb
+++ b/lib/scout_apm/logging/loggers/proxy.rb
@@ -19,10 +19,17 @@ module ScoutApm
           @loggers << logger
         end
 
-        def remove_scout_loggers(logger)
+        def remove_scout_loggers!(logger)
           @loggers.reject! { |inst_log| inst_log == logger }
 
           @loggers
+        end
+
+        def swap_scout_loggers!(old_logger, new_logger)
+          logger_index = @loggers.index(old_logger)
+          return unless logger_index
+
+          @loggers[logger_index] = new_logger
         end
 
         # We don't want other libraries to change the formatter of the logger we create.

--- a/lib/scout_apm_logging.rb
+++ b/lib/scout_apm_logging.rb
@@ -18,7 +18,7 @@ module ScoutApm
     if defined?(Rails) && defined?(Rails::Railtie)
       # If we are in a Rails environment, setup the monitor daemon manager.
       class RailTie < ::Rails::Railtie
-        initializer 'scout_apm_logging.monitor' do
+        initializer 'scout_apm_logging.monitor', after: :initialize_logger, before: :initialize_cache do
           context = ScoutApm::Logging::MonitorManager.instance.context
 
           Loggers::Capture.new(context).setup!


### PR DESCRIPTION
Updates the gem to now be a bit more sturdy when other libraries may also be trying to update the Rails logger.

We move up the initialization to be after the Rails logger initializes (so any logger set via the config is captured by the proxy) and before the cache:
https://github.com/rails/rails/blob/v7.0.8.4/railties/lib/rails/application/bootstrap.rb#L36

This puts us pretty early in the boot process, and then we patch the `Rails.logger=` setter method to now update the proxy logger instead of overwriting us