### PR TITLE
Bump protobuf version

### DIFF
--- a/scout_apm_logging.gemspec
+++ b/scout_apm_logging.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.6'
 
   s.add_dependency 'googleapis-common-protos-types'
-  s.add_dependency 'google-protobuf', '< 3.22.2'
+  s.add_dependency 'google-protobuf', '~> 3.0'
   s.add_dependency 'opentelemetry-api'
   s.add_dependency 'opentelemetry-common'
   s.add_dependency 'opentelemetry-instrumentation-base'

--- a/scout_apm_logging.gemspec
+++ b/scout_apm_logging.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.6'
 
   s.add_dependency 'googleapis-common-protos-types'
-  s.add_dependency 'google-protobuf', '< 3.18'
+  s.add_dependency 'google-protobuf', '< 3.22.2'
   s.add_dependency 'opentelemetry-api'
   s.add_dependency 'opentelemetry-common'
   s.add_dependency 'opentelemetry-instrumentation-base'


### PR DESCRIPTION
Set dependency of protobuf to be less than 4. This way we can use the older protobuf DSL (and not the newer serialized proto) but will contain builds for arm-darwin and supports higher versions of Ruby.