### PR TITLE
Re-add logging config on startup

### DIFF
--- a/lib/scout_apm_logging.rb
+++ b/lib/scout_apm_logging.rb
@@ -17,6 +17,7 @@ module ScoutApm
         initializer 'scout_apm_logging.monitor', after: :initialize_logger, before: :initialize_cache do
           context = Context.new
           context.config = Config.with_file(context, context.config.value('config_file'))
+          context.config.log_settings(context.logger)
 
           Loggers::Capture.new(context).setup!
         end


### PR DESCRIPTION
This was removed with the removal of the collector daemon and wasn't added back.