### PR TITLE
Upgrade protobuf version

### DIFF
--- a/scout_apm_logging.gemspec
+++ b/scout_apm_logging.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.6'
 
   s.add_dependency 'googleapis-common-protos-types'
-  s.add_dependency 'google-protobuf', '~> 3.0'
+  s.add_dependency 'google-protobuf', '~> 4.3'
   s.add_dependency 'opentelemetry-api'
   s.add_dependency 'opentelemetry-common'
   s.add_dependency 'opentelemetry-instrumentation-base'


### PR DESCRIPTION
Bumps google-protobuf dependency to version 4.3 so the gem can be installed in projects with latest ruby version 3.4.2

resolves #89 