### PR TITLE
Fix entrypoint name capturing for namespaced controllers

### DIFF
--- a/lib/scout_apm/logging/loggers/formatter.rb
+++ b/lib/scout_apm/logging/loggers/formatter.rb
@@ -60,9 +60,9 @@ module ScoutApm
           name_parts = layer_parts[0..-2]
           action = layer_parts[-1]
 
-          return {} unless name_parts.any? && action
+          return {} unless name_parts.any?
 
-          updated_name = name_parts.map(&:capitalize).map{|item| item.split("_").map(&:capitalize).join}.join("::")
+          updated_name = name_parts.map(&:capitalize).map { |item| item.split('_').map(&:capitalize).join }.join('::')
 
           derived_key = "#{layer.type.downcase}_entrypoint".to_sym
 

--- a/lib/scout_apm/logging/loggers/formatter.rb
+++ b/lib/scout_apm/logging/loggers/formatter.rb
@@ -56,11 +56,13 @@ module ScoutApm
 
           return {} unless layer
 
-          name, action = layer.name.split('/')
+          layer_parts = layer.name.split('/')
+          name_parts = layer_parts[0..-2]
+          action = layer_parts[-1]
 
-          return {} unless name
+          return {} unless name_parts.any? && action
 
-          updated_name = name.split('_').map(&:capitalize).join
+          updated_name = name_parts.map(&:capitalize).map{|item| item.split("_").map(&:capitalize).join}.join("::")
 
           derived_key = "#{layer.type.downcase}_entrypoint".to_sym
 

--- a/lib/scout_apm/logging/loggers/formatter.rb
+++ b/lib/scout_apm/logging/loggers/formatter.rb
@@ -56,9 +56,14 @@ module ScoutApm
 
           return {} unless layer
 
+          layer_type = layer.type.downcase
+
           layer_parts = layer.name.split('/')
-          name_parts = layer_parts[0..-2]
-          action = layer_parts[-1]
+          name_parts, action = if layer_type == 'controller'
+                                 [layer_parts[0..-2], layer_parts[-1]]
+                               else
+                                 [layer_parts, nil]
+                               end
 
           return {} unless name_parts.any?
 
@@ -70,7 +75,7 @@ module ScoutApm
           derived_value_of_scout_name = if action
                                           "#{updated_name}#{layer.type.capitalize}##{action}"
                                         else
-                                          name
+                                          name_parts[0]
                                         end
 
           { derived_key => derived_value_of_scout_name }


### PR DESCRIPTION
We are incorrectly capturing entrypoint names for namespaced controllers.

For example:

|Layer name|Result|Expected|Is correct|
| -------- | ------- | ------- | ------- |
|some_logic/action|SomeLogicController#action|SomeLogicController#action|Yes|
|api/some_logic/action|ApiController#some_logic|Api::SomeLogicController#action|No|
|api/v1/some_logic/action|ApiController#V1|Api::V1::SomeLogicController#action|No|