### PR TITLE
Update vendored SDK to 0.2.0

### DIFF
--- a/lib/scout_apm/logging/loggers/formatter.rb
+++ b/lib/scout_apm/logging/loggers/formatter.rb
@@ -36,7 +36,7 @@ module ScoutApm
           ).on_emit(
             severity_text: severity,
             severity_number: ::Logger::Severity.const_get(severity),
-            attributes: attributes_to_log,
+            attributes: attributes_to_log.transform_keys(&:to_s),
             timestamp: time,
             body: msg,
             context: ::OpenTelemetry::Context.current

--- a/lib/scout_apm/logging/loggers/opentelemetry/sdk/logs.rb
+++ b/lib/scout_apm/logging/loggers/opentelemetry/sdk/logs.rb
@@ -11,6 +11,7 @@ require_relative 'logs/log_record'
 require_relative 'logs/log_record_data'
 require_relative 'logs/log_record_processor'
 require_relative 'logs/export'
+require_relative 'logs/log_record_limits'
 
 module ScoutApm
   module Logging

--- a/lib/scout_apm/logging/loggers/opentelemetry/sdk/logs/export/batch_log_record_processor.rb
+++ b/lib/scout_apm/logging/loggers/opentelemetry/sdk/logs/export/batch_log_record_processor.rb
@@ -3,7 +3,6 @@
 # Copyright The OpenTelemetry Authors
 #
 # SPDX-License-Identifier: Apache-2.0
-
 module ScoutApm
   module Logging
     module Loggers
@@ -41,9 +40,8 @@ module ScoutApm
                               exporter_timeout: Float(ENV.fetch('OTEL_BLRP_EXPORT_TIMEOUT', 30_000)),
                               schedule_delay: Float(ENV.fetch('OTEL_BLRP_SCHEDULE_DELAY', 1000)),
                               max_queue_size: Integer(ENV.fetch('OTEL_BLRP_MAX_QUEUE_SIZE', 2048)),
-                              max_export_batch_size: Integer(ENV.fetch('OTEL_BLRP_MAX_EXPORT_BATCH_SIZE', 256)),
+                              max_export_batch_size: Integer(ENV.fetch('OTEL_BLRP_MAX_EXPORT_BATCH_SIZE', 512)),
                               start_thread_on_boot: String(ENV['OTEL_RUBY_BLRP_START_THREAD_ON_BOOT']) !~ /false/i)
-
                   unless max_export_batch_size <= max_queue_size
                     raise ArgumentError,
                           'max_export_batch_size much be less than or equal to max_queue_size'

--- a/lib/scout_apm/logging/loggers/opentelemetry/sdk/logs/log_record_data.rb
+++ b/lib/scout_apm/logging/loggers/opentelemetry/sdk/logs/log_record_data.rb
@@ -16,7 +16,7 @@ module ScoutApm
                                       :severity_text,             # optional String
                                       :severity_number,           # optional Integer
                                       :body,                      # optional String, Numeric, Boolean, Array<String, Numeric, Boolean>, Hash{String => String, Numeric, Boolean, Array<String, Numeric, Boolean>}
-                                      :attributes, # optional Hash{String => String, Numeric, Boolean, Array<String, Numeric, Boolean>}
+                                      :attributes,                # optional Hash{String => String, Numeric, Boolean, Array<String, Numeric, Boolean>}
                                       :trace_id,                  # optional String (16-byte binary)
                                       :span_id,                   # optional String (8-byte binary)
                                       :trace_flags,               # optional Integer (8-bit byte of bit flags)

--- a/lib/scout_apm/logging/loggers/opentelemetry/sdk/logs/log_record_limits.rb
+++ b/lib/scout_apm/logging/loggers/opentelemetry/sdk/logs/log_record_limits.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module ScoutApm
+  module Logging
+    module Loggers
+      module OpenTelemetry
+        module SDK
+          module Logs
+            # Class that holds log record attribute limit parameters.
+            class LogRecordLimits
+              # The global default max number of attributes per {LogRecord}.
+              attr_reader :attribute_count_limit
+
+              # The global default max length of attribute value per {LogRecord}.
+              attr_reader :attribute_length_limit
+
+              # Returns a {LogRecordLimits} with the desired values.
+              #
+              # @return [LogRecordLimits] with the desired values.
+              # @raise [ArgumentError] if any of the max numbers are not positive.
+              def initialize(attribute_count_limit: Integer(::OpenTelemetry::Common::Utilities.config_opt(
+                                                              'OTEL_LOG_RECORD_ATTRIBUTE_COUNT_LIMIT',
+                                                              'OTEL_ATTRIBUTE_COUNT_LIMIT',
+                                                              default: 128
+                                                            )),
+                            attribute_length_limit: ::OpenTelemetry::Common::Utilities.config_opt(
+                              'OTEL_LOG_RECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT',
+                              'OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT'
+                            ))
+                raise ArgumentError, 'attribute_count_limit must be positive' unless attribute_count_limit.positive?
+                raise ArgumentError, 'attribute_length_limit must not be less than 32' unless attribute_length_limit.nil? || Integer(attribute_length_limit) >= 32
+
+                @attribute_count_limit = attribute_count_limit
+                @attribute_length_limit = attribute_length_limit.nil? ? nil : Integer(attribute_length_limit)
+              end
+
+              # The default {LogRecordLimits}.
+              DEFAULT = new
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/scout_apm/logging/loggers/opentelemetry/sdk/logs/log_record_processor.rb
+++ b/lib/scout_apm/logging/loggers/opentelemetry/sdk/logs/log_record_processor.rb
@@ -3,7 +3,6 @@
 # Copyright The OpenTelemetry Authors
 #
 # SPDX-License-Identifier: Apache-2.0
-
 module ScoutApm
   module Logging
     module Loggers
@@ -29,7 +28,7 @@ module ScoutApm
               # the process after an invocation, but before the `Processor` exports
               # the completed spans.
               #
-              # @param [Numeric] timeout An optional timeout in seconds.
+              # @param [optional Numeric] timeout An optional timeout in seconds.
               # @return [Integer] Export::SUCCESS if no error occurred, Export::FAILURE if
               #   a non-specific failure occurred, Export::TIMEOUT if a timeout occurred.
               def force_flush(timeout: nil)
@@ -38,7 +37,7 @@ module ScoutApm
 
               # Called when {LoggerProvider#shutdown} is called.
               #
-              # @param [Numeric] timeout An optional timeout in seconds.
+              # @param [optional Numeric] timeout An optional timeout in seconds.
               # @return [Integer] Export::SUCCESS if no error occurred, Export::FAILURE if
               #   a non-specific failure occurred, Export::TIMEOUT if a timeout occurred.
               def shutdown(timeout: nil)

--- a/lib/scout_apm/logging/loggers/opentelemetry/sdk/logs/logger.rb
+++ b/lib/scout_apm/logging/loggers/opentelemetry/sdk/logs/logger.rb
@@ -37,6 +37,8 @@ module ScoutApm
               # @param [optional OpenTelemetry::Trace::SpanContext] span_context The
               #   OpenTelemetry::Trace::SpanContext to associate with the
               #   {LogRecord}.
+              # @param [optional String] severity_text Original string representation of
+              #   the severity as it is known at the source. Also known as log level.
               # @param severity_number [optional Integer] Numerical value of the
               #   severity. Smaller numerical values correspond to less severe events
               #   (such as debug events), larger numerical values correspond to more
@@ -72,6 +74,8 @@ module ScoutApm
                           span_id: nil,
                           trace_flags: nil,
                           context: ::OpenTelemetry::Context.current)
+                current_span = ::OpenTelemetry::Trace.current_span(context)
+                span_context = current_span.context unless current_span == ::OpenTelemetry::Trace::Span::INVALID
 
                 @logger_provider.on_emit(timestamp: timestamp,
                                         observed_timestamp: observed_timestamp,
@@ -79,9 +83,9 @@ module ScoutApm
                                         severity_number: severity_number,
                                         body: body,
                                         attributes: attributes,
-                                        trace_id: nil,
-                                        span_id: nil,
-                                        trace_flags: nil,
+                                        trace_id: trace_id || span_context&.trace_id,
+                                        span_id: span_id || span_context&.span_id,
+                                        trace_flags: trace_flags || span_context&.trace_flags,
                                         instrumentation_scope: @instrumentation_scope,
                                         context: context)
               end

--- a/lib/scout_apm/logging/loggers/opentelemetry/sdk/logs/version.rb
+++ b/lib/scout_apm/logging/loggers/opentelemetry/sdk/logs/version.rb
@@ -11,7 +11,7 @@ module ScoutApm
         module SDK
           module Logs
             # Current OpenTelemetry logs sdk version
-            VERSION = '0.1.0'
+            VERSION = '0.2.0'
           end
         end
       end


### PR DESCRIPTION
Bumps the vendored opentelemetry-sdk to the latest version (0.2.0). We are currently using the pre released version.