### PR TITLE
Benchmark test for capturing log file and number in log message

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     env:
       DOCKER_RUBY_VERSION: ${{ matrix.ruby }}
       BUNDLE_GEMFILE: gems/rails.gemfile
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Extract Library Version

--- a/gems/rails.gemfile
+++ b/gems/rails.gemfile
@@ -2,3 +2,4 @@ eval_gemfile("../Gemfile")
 
 gem "rails"
 gem "puma"
+gem "benchmark-ips"

--- a/lib/scout_apm/logging/loggers/formatter.rb
+++ b/lib/scout_apm/logging/loggers/formatter.rb
@@ -26,21 +26,21 @@ module ScoutApm
           attributes_to_log.merge!(scout_layer)
           attributes_to_log.merge!(scout_context)
           # Naive local benchmarks show this takes around 200 microseconds. As such, we only apply it to WARN and above.
-          attributes_to_log.merge!(local_log_location) if ::Logger::Severity.const_get(severity) >= ::Logger::Severity::WARN
+          # attributes_to_log.merge!(local_log_location) if ::Logger::Severity.const_get(severity) >= ::Logger::Severity::WARN
 
           message = "#{attributes_to_log.to_json}\n"
 
-          ScoutApm::Logging::Loggers::OpenTelemetry.logger_provider.logger(
-            name: 'scout_apm',
-            version: '0.1.0'
-          ).on_emit(
-            severity_text: severity,
-            severity_number: ::Logger::Severity.const_get(severity),
-            attributes: attributes_to_log.transform_keys(&:to_s),
-            timestamp: time,
-            body: msg,
-            context: ::OpenTelemetry::Context.current
-          )
+          # ScoutApm::Logging::Loggers::OpenTelemetry.logger_provider.logger(
+          #   name: 'scout_apm',
+          #   version: '0.1.0'
+          # ).on_emit(
+          #   severity_text: severity,
+          #   severity_number: ::Logger::Severity.const_get(severity),
+          #   attributes: attributes_to_log.transform_keys(&:to_s),
+          #   timestamp: time,
+          #   body: msg,
+          #   context: ::OpenTelemetry::Context.current
+          # )
           message
         end
 

--- a/lib/scout_apm/logging/loggers/logger.rb
+++ b/lib/scout_apm/logging/loggers/logger.rb
@@ -7,6 +7,37 @@ module ScoutApm
       class FileLogger < ::Logger
         include ::ActiveSupport::LoggerSilence if const_defined?('::ActiveSupport::LoggerSilence')
 
+        alias_method :original_warn, :warn
+
+        def warn_first(msg, *args)
+            # Get the caller (this returns the stack trace where the method was called from)
+            caller_info = caller(1).first  # Get the first entry in the call stack
+            file, line = caller_info.split(':')  # Split the string into file and line number
+
+            # Log the message with the file and line number where the log was called
+            original_warn("(#{file}:#{line}): #{msg}")
+        end
+
+        def warn_two(msg, *args)
+          # Get the caller (this returns the stack trace where the method was called from)
+          caller_info = caller_locations.lazy.drop(1).first  # Get the first entry in the call stack
+          file = caller_info.path.split("/")[-1]  # Split the string into file and line number
+          line = caller_info.lineno
+
+          # Log the message with the file and line number where the log was called
+          original_warn("(#{file}:#{line}): #{msg}")
+      end
+
+      def warn_three(msg)
+        last_local_location = caller[0..15].find { |path| path.include?(Rails.root.to_s) }
+        file = last_local_location.split("/")[-1]  # Split the string into file and line number
+        line = last_local_location.split(":")[-1]
+        # Log the message with the file and line number where the log was called
+        original_warn("(#{file}:#{line}): #{msg}")
+      end
+      # alias_method :warn, :warn_two
+
+
         # Other loggers may be extended with additional methods that have not been applied to this file logger.
         # Most likely, these methods will still utilize the exiting logging methods to write to the IO device,
         # however, if this is not the case we may miss logs. With that being said, we shouldn't impact the original

--- a/lib/scout_apm/logging/loggers/logger.rb
+++ b/lib/scout_apm/logging/loggers/logger.rb
@@ -28,6 +28,16 @@ module ScoutApm
           original_warn("(#{file}:#{line}): #{msg}")
       end
 
+      def warn_four(msg, *args)
+        # Get the caller (this returns the stack trace where the method was called from)
+        caller_info = caller_locations(2,1).first  # Get the first entry in the call stack
+        file = caller_info.path.split("/")[-1]  # Split the string into file and line number
+        line = caller_info.lineno
+
+        # Log the message with the file and line number where the log was called
+        original_warn("(#{file}:#{line}): #{msg}")
+    end
+
       def warn_three(msg)
         last_local_location = caller[0..15].find { |path| path.include?(Rails.root.to_s) }
         file = last_local_location.split("/")[-1]  # Split the string into file and line number

--- a/lib/scout_apm/logging/loggers/logger.rb
+++ b/lib/scout_apm/logging/loggers/logger.rb
@@ -112,6 +112,20 @@ module ScoutApm
       @find_log_location_2 = nil
     end
 
+    def warn_ten(msg, *args)
+      caller_info = find_log_location_3
+
+      file = caller_info.path.split("/")[-1]  # Split the string into file and line number
+      line = caller_info.lineno
+
+      # Log the message with the file and line number where the log was called
+      original_warn("(#{file}:#{line}): #{msg}")
+
+      get_call_stack_for_attribute
+      @call_stack_2 = nil
+      @find_log_location_3 = nil
+    end
+
 
       def warn_three(msg)
         last_local_location = caller[0..15].find { |path| path.include?(Rails.root.to_s) }
@@ -155,8 +169,16 @@ module ScoutApm
           @call_stack ||= caller_locations(4, 15)
         end
 
+        def call_stack_2
+          @call_stack_2 ||= caller_locations(4, 20)
+        end
+
         def find_log_location_2
           @find_log_location_2 ||= filter_log_location(call_stack)
+        end
+
+        def find_log_location_3
+          @find_log_location_3 ||= filter_log_location(call_stack_2)
         end
 
         def get_call_stack_for_attribute

--- a/lib/scout_apm/logging/loggers/logger.rb
+++ b/lib/scout_apm/logging/loggers/logger.rb
@@ -71,6 +71,48 @@ module ScoutApm
       original_warn("(#{file}:#{line}): #{msg}")
     end
 
+    def warn_seven(msg, *args)
+      caller_info = find_log_location_2
+
+      file = caller_info.path.split("/")[-1]  # Split the string into file and line number
+      line = caller_info.lineno
+
+      # Log the message with the file and line number where the log was called
+      original_warn("(#{file}:#{line}): #{msg}")
+
+      @call_stack = nil
+      @find_log_location_2 = nil
+    end
+
+    def warn_eight(msg, *args)
+      caller_info = find_log_location_2
+
+      file = caller_info.path.split("/")[-1]  # Split the string into file and line number
+      line = caller_info.lineno
+
+      # Log the message with the file and line number where the log was called
+      original_warn("(#{file}:#{line}): #{msg}")
+
+      get_call_stack_for_attribute
+      @call_stack = nil
+      @find_log_location_2 = nil
+    end
+
+    def warn_nine(msg, *args)
+      caller_info = find_log_location_2
+
+      file = caller_info.path.split("/")[-1]  # Split the string into file and line number
+      line = caller_info.lineno
+
+      # Log the message with the file and line number where the log was called
+      original_warn("(#{file}:#{line}): #{msg}")
+
+      get_call_stack_for_attribute_2
+      @call_stack = nil
+      @find_log_location_2 = nil
+    end
+
+
       def warn_three(msg)
         last_local_location = caller[0..15].find { |path| path.include?(Rails.root.to_s) }
         file = last_local_location.split("/")[-1]  # Split the string into file and line number
@@ -78,6 +120,7 @@ module ScoutApm
         # Log the message with the file and line number where the log was called
         original_warn("(#{file}:#{line}): #{msg}")
       end
+      
       # alias_method :warn, :warn_two
 
 
@@ -97,6 +140,44 @@ module ScoutApm
         end
 
         private 
+
+        def filter_log_location(the_call_stack = caller_locations)
+          rails_location = the_call_stack.find { |loc| loc.path.include?(Rails.root.to_s) }
+          return rails_location if rails_location
+
+          the_call_stack
+            .reject { |loc| loc.path.include?('lib/scout_apm/logging') }
+            .reject { |loc| loc.path.include?('broadcast_logger.rb') }
+            .first
+        end
+
+        def call_stack
+          @call_stack ||= caller_locations(4, 15)
+        end
+
+        def find_log_location_2
+          @find_log_location_2 ||= filter_log_location(call_stack)
+        end
+
+        def get_call_stack_for_attribute
+          call_stack
+            .map(&:to_s)
+            .reject { |loc| loc.include?('scout_apm/logging') }
+            .reject { |loc| loc.include?('broadcast_logger.rb') }
+            .join("\n")
+        end
+
+        def get_call_stack_for_attribute_2
+          call_stack
+            .each_with_object([]) do |loc, arr|
+              str = loc.to_s
+              unless str.include?('scout_apm/logging') || str.include?('broadcast_logger.rb')
+                arr << str
+              end
+            end
+            .join("\n")
+        end
+        
 
         def find_log_location
           @location ||= begin

--- a/lib/scout_apm/logging/loggers/logger.rb
+++ b/lib/scout_apm/logging/loggers/logger.rb
@@ -126,6 +126,21 @@ module ScoutApm
       @find_log_location_3 = nil
     end
 
+    def warn_eleven(msg, *args)
+      caller_info = find_log_location_2
+
+      file = caller_info.path.split("/")[-1]  # Split the string into file and line number
+      line = caller_info.lineno
+
+      # Log the message with the file and line number where the log was called
+      original_warn("(#{file}:#{line}): #{msg}")
+
+      Thread.current['scout_log_location'] = get_call_stack_for_attribute
+      @call_stack = nil
+      @find_log_location_2 = nil
+      Thread.current['scout_log_location'] = nil
+    end
+
 
       def warn_three(msg)
         last_local_location = caller[0..15].find { |path| path.include?(Rails.root.to_s) }

--- a/lib/scout_apm/logging/loggers/logger.rb
+++ b/lib/scout_apm/logging/loggers/logger.rb
@@ -38,6 +38,16 @@ module ScoutApm
         original_warn("(#{file}:#{line}): #{msg}")
     end
 
+    def warn_five(msg, *args)
+      # Get the caller (this returns the stack trace where the method was called from)
+      caller_info = caller_locations(1,10).find {|loc| loc.path.include?(Rails.root.to_s)}  # Get the first entry in the call stack
+      file = caller_info.path.split("/")[-1]  # Split the string into file and line number
+      line = caller_info.lineno
+
+      # Log the message with the file and line number where the log was called
+      original_warn("(#{file}:#{line}): #{msg}")
+    end
+
       def warn_three(msg)
         last_local_location = caller[0..15].find { |path| path.include?(Rails.root.to_s) }
         file = last_local_location.split("/")[-1]  # Split the string into file and line number

--- a/spec/rails/app.rb
+++ b/spec/rails/app.rb
@@ -53,6 +53,9 @@ class RootController < ActionController::Base
       b.report('patched_warn_10') do
         Rails.logger.warn_ten('Add location log attributes')
       end
+      b.report('patched_warn_11') do
+        Rails.logger.warn_eleven('Add location log attributes')
+      end
       b.report('original_warn') do
         Rails.logger.original_warn('Add location log attributes')
       end

--- a/spec/rails/app.rb
+++ b/spec/rails/app.rb
@@ -38,6 +38,9 @@ class RootController < ActionController::Base
       b.report('patched_warn_5') do
         Rails.logger.warn_five('Add location log attributes')
       end
+      b.report('patched_warn_6') do
+        Rails.logger.warn_six('Add location log attributes')
+      end
       b.report('original_warn') do
         Rails.logger.original_warn('Add location log attributes')
       end

--- a/spec/rails/app.rb
+++ b/spec/rails/app.rb
@@ -35,6 +35,9 @@ class RootController < ActionController::Base
       b.report('patched_warn_4') do
         Rails.logger.warn_four('Add location log attributes')
       end
+      b.report('patched_warn_5') do
+        Rails.logger.warn_five('Add location log attributes')
+      end
       b.report('original_warn') do
         Rails.logger.original_warn('Add location log attributes')
       end

--- a/spec/rails/app.rb
+++ b/spec/rails/app.rb
@@ -32,6 +32,9 @@ class RootController < ActionController::Base
       b.report('patched_warn_3') do
         Rails.logger.warn_three('Add location log attributes')
       end
+      b.report('patched_warn_4') do
+        Rails.logger.warn_four('Add location log attributes')
+      end
       b.report('original_warn') do
         Rails.logger.original_warn('Add location log attributes')
       end

--- a/spec/rails/app.rb
+++ b/spec/rails/app.rb
@@ -41,6 +41,15 @@ class RootController < ActionController::Base
       b.report('patched_warn_6') do
         Rails.logger.warn_six('Add location log attributes')
       end
+      b.report('patched_warn_7') do
+        Rails.logger.warn_seven('Add location log attributes')
+      end
+      b.report('patched_warn_8') do
+        Rails.logger.warn_eight('Add location log attributes')
+      end
+      b.report('patched_warn_9') do
+        Rails.logger.warn_nine('Add location log attributes')
+      end
       b.report('original_warn') do
         Rails.logger.original_warn('Add location log attributes')
       end

--- a/spec/rails/app.rb
+++ b/spec/rails/app.rb
@@ -50,6 +50,9 @@ class RootController < ActionController::Base
       b.report('patched_warn_9') do
         Rails.logger.warn_nine('Add location log attributes')
       end
+      b.report('patched_warn_10') do
+        Rails.logger.warn_ten('Add location log attributes')
+      end
       b.report('original_warn') do
         Rails.logger.original_warn('Add location log attributes')
       end

--- a/spec/rails/app.rb
+++ b/spec/rails/app.rb
@@ -4,6 +4,7 @@ begin
 rescue LoadError # rubocop:disable Lint/SuppressedException
 end
 
+require 'benchmark/ips'
 require 'action_controller/railtie'
 require 'logger'
 require 'scout_apm_logging'
@@ -21,7 +22,22 @@ end
 
 class RootController < ActionController::Base
   def index
-    Rails.logger.warn('Add location log attributes')
+    Benchmark.ips do |b|
+      b.report('patched_warn') do
+        Rails.logger.warn_first('Add location log attributes')
+      end
+      b.report('patched_warn_2') do
+        Rails.logger.warn_two('Add location log attributes')
+      end
+      b.report('patched_warn_3') do
+        Rails.logger.warn_three('Add location log attributes')
+      end
+      b.report('original_warn') do
+        Rails.logger.original_warn('Add location log attributes')
+      end
+      b.compare!
+    end
+
     Rails.logger.tagged('TEST').info('Some log')
     Rails.logger.tagged('YIELD') { logger.info('Yield Test') }
     Rails.logger.info('Another Log')


### PR DESCRIPTION
These tests aren't meant to pass but log/show benchmark numbers. 

Appears to add 20 μs - 40 μs per a log call. Seems worth it.

For example, updates:
`Add location log attributes`
To:
`(app.rb:30): Add location log attributes`

For every log call -- be it info, warn, etc.

Doesn't actually call `warn`, we alias away the warn on the FileLogger, as this will call the Rails broadcast logger which will also log to `stdout` which messes with the benchmarking. These benches still write to the /tmp log file we have.

UPDATE:
Patch 11 is what will be implemented. This allows us to capture the log line in the message and the call stack in the attributes. Patch 3 is how we are currently capturing the log location, only a single frame, for WARN+ level logs.

```
Calculating -------------------------------------
        patched_warn
  0     0    0     0    0     0      0      0 --:--:--  0:00:24 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:25 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:26 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:27 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:28 --:--:--     0     13.700k (± 2.3%) i/s   (72.99 μs/i) -     68.724k in   5.019153s
      patched_warn_2
  0     0    0     0    0     0      0      0 --:--:--  0:00:29 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:30 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:31 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:32 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:33 --:--:--     0     21.765k (± 2.4%) i/s   (45.95 μs/i) -    109.824k in   5.048960s
      patched_warn_3
  0     0    0     0    0     0      0      0 --:--:--  0:00:34 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:35 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:36 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:37 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:38 --:--:--     0     12.663k (± 2.6%) i/s   (78.97 μs/i) -     63.312k in   5.003449s
      patched_warn_4
  0     0    0     0    0     0      0      0 --:--:--  0:00:39 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:40 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:41 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:42 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:43 --:--:--     0     40.765k (± 2.9%) i/s   (24.53 μs/i) -    205.898k in   5.055233s
      patched_warn_5
  0     0    0     0    0     0      0      0 --:--:--  0:00:44 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:45 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:46 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:47 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:48 --:--:--     0     33.997k (± 3.8%) i/s   (29.41 μs/i) -    172.650k in   5.085812s
      patched_warn_6
  0     0    0     0    0     0      0      0 --:--:--  0:00:49 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:50 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:51 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:52 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:53 --:--:--     0     33.281k (± 3.6%) i/s   (30.05 μs/i) -    166.845k in   5.019943s
      patched_warn_7
  0     0    0     0    0     0      0      0 --:--:--  0:00:54 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:55 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:56 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:57 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:58 --:--:--     0     33.082k (± 3.0%) i/s   (30.23 μs/i) -    165.914k in   5.019761s
      patched_warn_8
  0     0    0     0    0     0      0      0 --:--:--  0:00:59 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:01:00 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:01:01 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:01:02 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:01:03 --:--:--     0     18.865k (± 6.2%) i/s   (53.01 μs/i) -     94.650k in   5.039813s
      patched_warn_9
  0     0    0     0    0     0      0      0 --:--:--  0:01:04 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:01:05 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:01:06 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:01:07 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:01:08 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:01:09 --:--:--     0     18.639k (± 6.9%) i/s   (53.65 μs/i) -     94.224k in   5.084727s
     patched_warn_10
  0     0    0     0    0     0      0      0 --:--:--  0:01:10 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:01:11 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:01:12 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:01:13 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:01:14 --:--:--     0     18.086k (± 6.5%) i/s   (55.29 μs/i) -     90.336k in   5.019920s
     patched_warn_11
  0     0    0     0    0     0      0      0 --:--:--  0:01:15 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:01:16 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:01:17 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:01:18 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:01:19 --:--:--     0     18.483k (± 6.4%) i/s   (54.10 μs/i) -     93.149k in   5.066059s
       original_warn
  0     0    0     0    0     0      0      0 --:--:--  0:01:20 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:01:21 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:01:22 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:01:23 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:01:24 --:--:--     0     48.381k (± 2.4%) i/s   (20.67 μs/i) -    242.580k in   5.017015s

Comparison:
       original_warn:    48380.9 i/s
      patched_warn_4:    40765.1 i/s - 1.19x  slower
      patched_warn_5:    33996.8 i/s - 1.42x  slower
      patched_warn_6:    33280.7 i/s - 1.45x  slower
      patched_warn_7:    33081.9 i/s - 1.46x  slower
      patched_warn_2:    21764.9 i/s - 2.22x  slower
      patched_warn_8:    18865.3 i/s - 2.56x  slower
      patched_warn_9:    18638.8 i/s - 2.60x  slower
     patched_warn_11:    18482.6 i/s - 2.62x  slower
     patched_warn_10:    18085.9 i/s - 2.68x  slower
        patched_warn:    13699.9 i/s - 3.53x  slower
      patched_warn_3:    12662.5 i/s - 3.82x  slower
```