### PR TITLE
Capture log line and call stack

### DIFF
--- a/lib/scout_apm/logging/config.rb
+++ b/lib/scout_apm/logging/config.rb
@@ -21,7 +21,8 @@
 # logs_proxy_log_dir - the directory to store logs in for monitoring
 # logs_capture_call_stack - true or false. If true, capture the call stack for each log message
 # logs_capture_log_line - true or false. If true, capture the log line for each log message
-# logs_call_stack_depth - the number of frames to capture in the call stack
+# logs_call_stack_search_depth - the number of frames to search in the call stack
+# logs_call_stack_capture_depth - the number of frames to capture in the call stack
 #
 # Any of these config settings can be set with an environment variable prefixed
 # by SCOUT_ and uppercasing the key: SCOUT_LOG_LEVEL for instance.
@@ -47,14 +48,16 @@ module ScoutApm
         logs_log_file_size
         logs_capture_call_stack
         logs_capture_log_line
-        logs_call_stack_depth
+        logs_call_stack_search_depth
+        logs_call_stack_capture_depth
       ].freeze
 
       SETTING_COERCIONS = {
         'logs_monitor' => BooleanCoercion.new,
         'logs_capture_call_stack' => BooleanCoercion.new,
         'logs_capture_log_line' => BooleanCoercion.new,
-        'logs_call_stack_depth' => IntegerCoercion.new,
+        'logs_call_stack_search_depth' => IntegerCoercion.new,
+        'logs_call_stack_capture_depth' => IntegerCoercion.new,
         'logs_log_file_size' => IntegerCoercion.new
       }.freeze
 
@@ -114,9 +117,10 @@ module ScoutApm
           'logs_reporting_endpoint_http' => 'https://otlp.scoutotel.com:4318/v1/logs',
           'logs_proxy_log_dir' => '/tmp/scout_apm/logs/',
           'logs_log_file_size' => 1024 * 1024 * 10,
-          'logs_capture_call_stack' => true,
-          'logs_capture_log_line' => true,
-          'logs_call_stack_depth' => 15
+          'logs_capture_call_stack' => false,
+          'logs_capture_log_line' => false,
+          'logs_call_stack_search_depth' => 15,
+          'logs_call_stack_capture_depth' => 2
         }.freeze
 
         def value(key)

--- a/lib/scout_apm/logging/config.rb
+++ b/lib/scout_apm/logging/config.rb
@@ -19,19 +19,9 @@
 # logs_config        - a hash of configuration options for merging into the collector's config
 # logs_reporting_endpoint - the endpoint to send logs to
 # logs_proxy_log_dir - the directory to store logs in for monitoring
-# manager_lock_file  - the location for obtaining an exclusive lock for running monitor manager
-# monitor_pid_file   - the location of the pid file for the monitor
-# monitor_state_file - the location of the state file for the monitor
-# monitor_interval   - the interval to check the collector healtcheck and for new state logs
-# monitor_interval_delay - the delay to wait before running the first monitor interval
-# collector_log_level - the log level for the collector
-# collector_sending_queue_storage_dir - the directory to store queue files
-# collector_offset_storage_dir - the directory to store offset files
-# collector_pid_file - the location of the pid file for the collector
-# collector_download_dir - the directory to store downloaded collector files
-# collector_config_file - the location of the config file for the collector
-# collector_version - the version of the collector to download
-# health_check_port - the port to use for the collector health check. Default is dynamically derived based on port availability
+# logs_capture_call_stack - true or false. If true, capture the call stack for each log message
+# logs_capture_log_line - true or false. If true, capture the log line for each log message
+# logs_call_stack_depth - the number of frames to capture in the call stack
 #
 # Any of these config settings can be set with an environment variable prefixed
 # by SCOUT_ and uppercasing the key: SCOUT_LOG_LEVEL for instance.
@@ -55,10 +45,16 @@ module ScoutApm
         logs_reporting_endpoint_http
         logs_proxy_log_dir
         logs_log_file_size
+        logs_capture_call_stack
+        logs_capture_log_line
+        logs_call_stack_depth
       ].freeze
 
       SETTING_COERCIONS = {
         'logs_monitor' => BooleanCoercion.new,
+        'logs_capture_call_stack' => BooleanCoercion.new,
+        'logs_capture_log_line' => BooleanCoercion.new,
+        'logs_call_stack_depth' => IntegerCoercion.new,
         'logs_log_file_size' => IntegerCoercion.new
       }.freeze
 
@@ -117,7 +113,10 @@ module ScoutApm
           'logs_reporting_endpoint' => 'https://otlp.scoutotel.com:4317',
           'logs_reporting_endpoint_http' => 'https://otlp.scoutotel.com:4318/v1/logs',
           'logs_proxy_log_dir' => '/tmp/scout_apm/logs/',
-          'logs_log_file_size' => 1024 * 1024 * 10
+          'logs_log_file_size' => 1024 * 1024 * 10,
+          'logs_capture_call_stack' => true,
+          'logs_capture_log_line' => true,
+          'logs_call_stack_depth' => 15
         }.freeze
 
         def value(key)

--- a/lib/scout_apm/logging/context.rb
+++ b/lib/scout_apm/logging/context.rb
@@ -7,6 +7,14 @@ module ScoutApm
       # The root of the application.
       attr_accessor :application_root
 
+      # Use this as the entrypoint.
+      def self.instance
+        @@instance ||= new.tap do |instance|
+          instance.config = ScoutApm::Logging::Config.with_file(instance, instance.config.value('config_file'))
+          instance.config.log_settings(instance.logger)
+        end
+      end
+
       # Initially start up without attempting to load a configuration file. We
       # need to be able to lookup configuration options like "application_root"
       # which would then in turn influence where the yaml configuration file is

--- a/lib/scout_apm/logging/loggers/formatter.rb
+++ b/lib/scout_apm/logging/loggers/formatter.rb
@@ -12,16 +12,18 @@ module ScoutApm
       class Formatter < ::Logger::Formatter
         DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%S.%LZ'
 
-        def call(severity, time, progname, msg, log_location = nil) # rubocop:disable Metrics/AbcSize
+        def call(severity, time, progname, msg) # rubocop:disable Metrics/AbcSize
           attributes_to_log = {
             severity: severity,
             time: format_datetime(time),
             msg: msg2str(msg)
           }
 
+          log_location = Thread.current[:scout_log_location]
+
           attributes_to_log[:progname] = progname if progname
           attributes_to_log['service.name'] = service_name
-          attributes_to_log['log_location'] = log_location.path if log_location
+          attributes_to_log['log_location'] = log_location if log_location
 
           attributes_to_log.merge!(scout_transaction_id)
           attributes_to_log.merge!(scout_layer)

--- a/lib/scout_apm/logging/loggers/formatter.rb
+++ b/lib/scout_apm/logging/loggers/formatter.rb
@@ -25,8 +25,6 @@ module ScoutApm
           attributes_to_log.merge!(scout_transaction_id)
           attributes_to_log.merge!(scout_layer)
           attributes_to_log.merge!(scout_context)
-          # Naive local benchmarks show this takes around 200 microseconds. As such, we only apply it to WARN and above.
-          attributes_to_log.merge!(local_log_location) if ::Logger::Severity.const_get(severity) >= ::Logger::Severity::WARN
 
           message = "#{attributes_to_log.to_json}\n"
 
@@ -101,15 +99,6 @@ module ScoutApm
 
         def scout_transaction_id
           { "scout_transaction_id": ScoutApm::RequestManager.lookup.transaction_id }
-        end
-
-        def local_log_location
-          # Should give us the last local stack which called the log within just the last couple frames.
-          last_local_location = caller[0..15].find { |path| path.include?(Rails.root.to_s) }
-
-          return {} unless last_local_location
-
-          { 'log_location' => last_local_location }
         end
 
         def context

--- a/lib/scout_apm/logging/loggers/formatter.rb
+++ b/lib/scout_apm/logging/loggers/formatter.rb
@@ -12,7 +12,7 @@ module ScoutApm
       class Formatter < ::Logger::Formatter
         DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%S.%LZ'
 
-        def call(severity, time, progname, msg) # rubocop:disable Metrics/AbcSize
+        def call(severity, time, progname, msg, log_location = nil) # rubocop:disable Metrics/AbcSize
           attributes_to_log = {
             severity: severity,
             time: format_datetime(time),
@@ -21,6 +21,7 @@ module ScoutApm
 
           attributes_to_log[:progname] = progname if progname
           attributes_to_log['service.name'] = service_name
+          attributes_to_log['log_location'] = log_location.path if log_location
 
           attributes_to_log.merge!(scout_transaction_id)
           attributes_to_log.merge!(scout_layer)

--- a/lib/scout_apm/logging/loggers/formatter.rb
+++ b/lib/scout_apm/logging/loggers/formatter.rb
@@ -12,7 +12,7 @@ module ScoutApm
       class Formatter < ::Logger::Formatter
         DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%S.%LZ'
 
-        def call(severity, time, progname, msg) # rubocop:disable Metrics/AbcSize
+        def call(severity, time, progname, msg)
           attributes_to_log = {
             severity: severity,
             time: format_datetime(time),
@@ -29,8 +29,14 @@ module ScoutApm
           attributes_to_log.merge!(scout_layer)
           attributes_to_log.merge!(scout_context)
 
-          message = "#{attributes_to_log.to_json}\n"
+          emit_log(msg, severity, time, attributes_to_log)
 
+          "#{attributes_to_log.to_json}\n"
+        end
+
+        private
+
+        def emit_log(msg, severity, time, attributes_to_log)
           ScoutApm::Logging::Loggers::OpenTelemetry.logger_provider.logger(
             name: 'scout_apm',
             version: '0.1.0'
@@ -42,10 +48,7 @@ module ScoutApm
             body: msg,
             context: ::OpenTelemetry::Context.current
           )
-          message
         end
-
-        private
 
         def format_datetime(time)
           time.utc.strftime(DATETIME_FORMAT)

--- a/lib/scout_apm/logging/loggers/logger.rb
+++ b/lib/scout_apm/logging/loggers/logger.rb
@@ -76,22 +76,31 @@ module ScoutApm
         private
 
         # Useful for testing.
-        def filter_log_location(call_stack = caller_locations)
-          rails_location = call_stack.find { |loc| loc.path.include?(Rails.root.to_s) }
+        def filter_log_location(the_call_stack = caller_locations)
+          rails_location = the_call_stack.find { |loc| loc.path.include?(Rails.root.to_s) }
           return rails_location if rails_location
 
-          call_stack
-            .reject { |loc| loc.path.include?('lib/scout_apm_logging') }
+          the_call_stack
+            .reject { |loc| loc.path.include?('scout_apm/logging') }
             .reject { |loc| loc.path.include?('broadcast_logger.rb') }
             .first
         end
 
+        def call_stack
+          @call_stack ||= caller_locations(4, 15)
+        end
+
         # Cache log location to reduce performance impact.
         def find_log_location
-          @find_log_location ||= begin
-            call_stack = caller_locations(1, 15)
-            filter_log_location(call_stack)
-          end
+          @find_log_location ||= filter_log_location(call_stack)
+        end
+
+        def get_call_stack_for_attribute
+          call_stack
+            .map(&:to_s)
+            .reject { |loc| loc.include?('scout_apm/logging') }
+            .reject { |loc| loc.include?('broadcast_logger.rb') }
+            .join("\n")
         end
 
         # Ideally, we would pass an additional argument to the formatter, but
@@ -99,8 +108,10 @@ module ScoutApm
         # this is a work around for tagged logging and incorrect passed arguments.
         # May need to move to fiber at some point.
         def format_message(severity, datetime, progname, msg)
-          Thread.current[:scout_log_location] = "#{find_log_location.path}:#{find_log_location.lineno}" if find_log_location
+          Thread.current[:scout_log_location] = get_call_stack_for_attribute
+
           super(severity, datetime, progname, msg).tap do |_|
+            @call_stack = nil
             @find_log_location = nil
             Thread.current[:scout_log_location] = nil
           end

--- a/lib/scout_apm_logging.rb
+++ b/lib/scout_apm_logging.rb
@@ -15,9 +15,7 @@ module ScoutApm
       # If we are in a Rails environment, setup the monitor daemon manager.
       class RailTie < ::Rails::Railtie
         initializer 'scout_apm_logging.monitor', after: :initialize_logger, before: :initialize_cache do
-          context = Context.new
-          context.config = Config.with_file(context, context.config.value('config_file'))
-          context.config.log_settings(context.logger)
+          context = ScoutApm::Logging::Context.instance
 
           Loggers::Capture.new(context).setup!
         end

--- a/spec/integration/rails/lifecycle_spec.rb
+++ b/spec/integration/rails/lifecycle_spec.rb
@@ -60,6 +60,8 @@ describe ScoutApm::Logging do
       end
     end
 
+    puts lines
+
     local_messages = lines.map { |item| item['msg'] }
     puts local_messages
 

--- a/spec/integration/rails/lifecycle_spec.rb
+++ b/spec/integration/rails/lifecycle_spec.rb
@@ -66,23 +66,23 @@ describe ScoutApm::Logging do
     puts local_messages
 
     # Verify we have all the logs in the local log file
-    expect(local_messages.count('[TEST] [app.rb:24] Some log')).to eq(1)
-    expect(local_messages.count('[YIELD] [app.rb:25] Yield Test')).to eq(1)
-    expect(local_messages.count('[app.rb:26] Another Log')).to eq(1)
-    expect(local_messages.count('[app.rb:27] Should not be captured')).to eq(0)
-    expect(local_messages.count('[app.rb:28] Warn level log')).to eq(1)
-    expect(local_messages.count('[app.rb:29] Error level log')).to eq(1)
-    expect(local_messages.count('[app.rb:30] Fatal level log')).to eq(1)
+    expect(local_messages.count('[TEST] Some log')).to eq(1)
+    expect(local_messages.count('[YIELD] Yield Test')).to eq(1)
+    expect(local_messages.count('Another Log')).to eq(1)
+    expect(local_messages.count('Should not be captured')).to eq(0)
+    expect(local_messages.count('Warn level log')).to eq(1)
+    expect(local_messages.count('Error level log')).to eq(1)
+    expect(local_messages.count('Fatal level log')).to eq(1)
 
     # Verify the logs are sent to the receiver
     receiver_contents = File.readlines(@file_path, chomp: true)
-    expect(receiver_contents.count('[TEST] [app.rb:24] Some log')).to eq(1)
-    expect(receiver_contents.count('[YIELD] [app.rb:25] Yield Test')).to eq(1)
-    expect(receiver_contents.count('[app.rb:26] Another Log')).to eq(1)
-    expect(receiver_contents.count('[app.rb:27] Should not be captured')).to eq(0)
-    expect(local_messages.count('[app.rb:28] Warn level log')).to eq(1)
-    expect(local_messages.count('[app.rb:29] Error level log')).to eq(1)
-    expect(local_messages.count('[app.rb:30] Fatal level log')).to eq(1)
+    expect(receiver_contents.count('[TEST] Some log')).to eq(1)
+    expect(receiver_contents.count('[YIELD] Yield Test')).to eq(1)
+    expect(receiver_contents.count('Another Log')).to eq(1)
+    expect(receiver_contents.count('Should not be captured')).to eq(0)
+    expect(local_messages.count('Warn level log')).to eq(1)
+    expect(local_messages.count('Error level log')).to eq(1)
+    expect(local_messages.count('Fatal level log')).to eq(1)
 
     # Kill the rails process. We use kill as using any other signal throws a long log line.
     Process.kill('KILL', rails_pid)

--- a/spec/integration/rails/lifecycle_spec.rb
+++ b/spec/integration/rails/lifecycle_spec.rb
@@ -6,7 +6,7 @@ require 'stringio'
 require_relative '../../rails/app'
 
 ScoutApm::Logging::Loggers::FileLogger.class_exec do
-  define_method(:first_app_location) do |locations|
+  define_method(:filter_log_location) do |locations|
     locations.find { |loc| loc.path.include?(Rails.root.to_s) && !loc.path.include?('scout_apm/logging') }
   end
 end

--- a/spec/integration/rails/lifecycle_spec.rb
+++ b/spec/integration/rails/lifecycle_spec.rb
@@ -5,6 +5,12 @@ require 'zlib'
 require 'stringio'
 require_relative '../../rails/app'
 
+ScoutApm::Logging::Loggers::FileLogger.class_exec do
+  define_method(:first_app_location) do |locations|
+    locations.find { |loc| loc.path.include?(Rails.root.to_s) && !loc.path.include?('scout_apm/logging') }
+  end
+end
+
 describe ScoutApm::Logging do
   before do
     @file_path = '/app/response_body.txt'
@@ -55,24 +61,26 @@ describe ScoutApm::Logging do
     end
 
     local_messages = lines.map { |item| item['msg'] }
+    puts local_messages
 
     # Verify we have all the logs in the local log file
-    expect(local_messages.count('[TEST] Some log')).to eq(1)
-    expect(local_messages.count('[YIELD] Yield Test')).to eq(1)
-    expect(local_messages.count('Another Log')).to eq(1)
-    expect(local_messages.count('Should not be captured')).to eq(0)
-
-    log_locations = lines.map { |item| item['log_location'] }.compact
-
-    # Verify that log attributes aren't persisted
-    expect(log_locations.size).to eq(1)
+    expect(local_messages.count('[TEST] [app.rb:24] Some log')).to eq(1)
+    expect(local_messages.count('[YIELD] [app.rb:25] Yield Test')).to eq(1)
+    expect(local_messages.count('[app.rb:26] Another Log')).to eq(1)
+    expect(local_messages.count('[app.rb:27] Should not be captured')).to eq(0)
+    expect(local_messages.count('[app.rb:28] Warn level log')).to eq(1)
+    expect(local_messages.count('[app.rb:29] Error level log')).to eq(1)
+    expect(local_messages.count('[app.rb:30] Fatal level log')).to eq(1)
 
     # Verify the logs are sent to the receiver
     receiver_contents = File.readlines(@file_path, chomp: true)
-    expect(receiver_contents.count('[TEST] Some log')).to eq(1)
-    expect(receiver_contents.count('[YIELD] Yield Test')).to eq(1)
-    expect(receiver_contents.count('Another Log')).to eq(1)
-    expect(receiver_contents.count('Should not be captured')).to eq(0)
+    expect(receiver_contents.count('[TEST] [app.rb:24] Some log')).to eq(1)
+    expect(receiver_contents.count('[YIELD] [app.rb:25] Yield Test')).to eq(1)
+    expect(receiver_contents.count('[app.rb:26] Another Log')).to eq(1)
+    expect(receiver_contents.count('[app.rb:27] Should not be captured')).to eq(0)
+    expect(local_messages.count('[app.rb:28] Warn level log')).to eq(1)
+    expect(local_messages.count('[app.rb:29] Error level log')).to eq(1)
+    expect(local_messages.count('[app.rb:30] Fatal level log')).to eq(1)
 
     # Kill the rails process. We use kill as using any other signal throws a long log line.
     Process.kill('KILL', rails_pid)

--- a/spec/rails/app.rb
+++ b/spec/rails/app.rb
@@ -20,12 +20,14 @@ class App < ::Rails::Application
 end
 
 class RootController < ActionController::Base
-  def index
-    Rails.logger.warn('Add location log attributes')
+  def index # rubocop:disable Metrics/AbcSize
     Rails.logger.tagged('TEST').info('Some log')
     Rails.logger.tagged('YIELD') { logger.info('Yield Test') }
     Rails.logger.info('Another Log')
     Rails.logger.debug('Should not be captured')
+    Rails.logger.warn('Warn level log')
+    Rails.logger.error('Error level log')
+    Rails.logger.fatal('Fatal level log')
 
     render plain: Rails.version
   end

--- a/spec/unit/loggers/logger_spec.rb
+++ b/spec/unit/loggers/logger_spec.rb
@@ -1,0 +1,74 @@
+require 'logger'
+require 'stringio'
+
+require 'spec_helper'
+
+require 'scout_apm_logging'
+
+ScoutApm::Logging::Loggers::Formatter.class_exec do
+  define_method(:emit_log) do |msg, severity, time, attributes_to_log|
+  end
+end
+
+def capture_stdout
+  old_stdout = $stdout
+  $stdout = StringIO.new
+  yield
+  $stdout.string
+ensure
+  $stdout = old_stdout
+end
+
+describe ScoutApm::Logging::Loggers::Logger do
+  it 'should not capture log line' do
+    ENV['SCOUT_LOGS_CAPTURE_LOG_LINE'] = 'false'
+    ScoutApm::Logging::Context.instance
+
+    output_from_log = capture_stdout do
+      logger = ScoutApm::Logging::Loggers::FileLogger.new($stdout).tap do |instance|
+        instance.level = 0
+        instance.formatter = ScoutApm::Logging::Loggers::Formatter.new
+      end
+
+      logger.info('Hi')
+    end
+
+    expect(output_from_log).to include('"log_location":"')
+    expect(output_from_log).not_to include('"msg":"[logger_spec.rb')
+    ENV['SCOUT_LOGS_CAPTURE_LOG_LINE'] = 'true' # set back to default
+  end
+
+  it 'should capture log line and call stack' do
+    ScoutApm::Logging::Context.instance
+
+    output_from_log = capture_stdout do
+      logger = ScoutApm::Logging::Loggers::FileLogger.new($stdout).tap do |instance|
+        instance.level = 0
+        instance.formatter = ScoutApm::Logging::Loggers::Formatter.new
+      end
+
+      logger.info('Hi')
+    end
+
+    expect(output_from_log).to include('"msg":"[logger_spec.rb')
+    expect(output_from_log).to include('"log_location":"')
+  end
+
+  it 'should not capture call stack' do
+    ENV['SCOUT_LOGS_CAPTURE_CALL_STACK'] = 'false'
+    ScoutApm::Logging::Context.instance
+
+    output_from_log = capture_stdout do
+      logger = ScoutApm::Logging::Loggers::FileLogger.new($stdout).tap do |instance|
+        instance.level = 0
+        instance.formatter = ScoutApm::Logging::Loggers::Formatter.new
+      end
+
+      logger.info('Hi')
+    end
+
+    expect(output_from_log).not_to include('"log_location":"')
+    expect(output_from_log).to include('"msg":"[logger_spec.rb')
+    ENV['SCOUT_LOGS_CAPTURE_CALL_STACK'] = 'true' # set back to default
+  end
+end


### PR DESCRIPTION
This attempts to capture the log file and call stack for the log.

Only captures the stack trace and log line for logs that we find originate from the Rails codebase. While this usually works well, if the callstack is small, we might end up hitting user defined custom Rails middleware. The search value below can be adjusted if need be.

In absolute terms, from [benchmarking](https://github.com/scoutapp/scout_apm_ruby_logging/pull/98), this adds about ~30-40 μs per each log call to capture the call stack.

There's probably a bit more tuning that can happen here, but this is a first pass at this.

Adds the following configurations:
* `logs_capture_call_stack` which defaults to `true`.
* `logs_capture_log_line` which defaults to `true`.
* `logs_call_stack_search_depth` which defaults to `15`.
* `logs_call_stack_capture_depth` which defaults to `2`.
