### PR TITLE
Update GHA workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     env:
       DOCKER_RUBY_VERSION: ${{ matrix.ruby }}
       BUNDLE_GEMFILE: gems/rails.gemfile
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Extract Library Version


### PR DESCRIPTION
There was a reason as to why we used 20, but it had to do with the collector, and isn't relevant anymore.