### PR TITLE
Add tests for ActionCable

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,6 +12,7 @@ AllCops:
 
 Metrics/BlockLength:
   Exclude:
+    - "scout_apm_logging.gemspec"
     - "spec/**/*"
 
 Metrics/ClassLength:

--- a/lib/scout_apm/logging/loggers/capture.rb
+++ b/lib/scout_apm/logging/loggers/capture.rb
@@ -56,7 +56,7 @@ module ScoutApm
           # Re-extend TaggedLogging to verify the patch is be applied.
           # This appears to be an issue in Ruby 2.7 with the broadcast logger.
           ruby_version = Gem::Version.new(RUBY_VERSION)
-          isruby27 = (ruby_version >= Gem::Version.new('2.7') && ruby_version < Gem::Version.new('3.0'))
+          isruby27 = ruby_version >= Gem::Version.new('2.7') && ruby_version < Gem::Version.new('3.0')
           return unless isruby27 && ::Rails.logger.respond_to?(:broadcasts)
 
           ::Rails.logger.broadcasts.each do |logger|

--- a/lib/scout_apm/logging/loggers/logger.rb
+++ b/lib/scout_apm/logging/loggers/logger.rb
@@ -90,8 +90,7 @@ module ScoutApm
 
         # Useful for testing.
         def filter_log_location(the_call_stack = caller_locations)
-          rails_location = the_call_stack.find { |loc| loc.path.include?(Rails.root.to_s) }
-          return rails_location if rails_location
+          the_call_stack.find { |loc| loc.path.include?(Rails.root.to_s) }
         end
 
         # Cache call stack to reduce performance impact.

--- a/scout_apm_logging.gemspec
+++ b/scout_apm_logging.gemspec
@@ -29,4 +29,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rubocop', '1.50.2'
   s.add_development_dependency 'rubocop-ast', '1.30.0'
   s.add_development_dependency 'webmock'
+  # Old, but works. It is a small wrapper library around websocket-eventmachine
+  # for ActionCable protocols.
+  s.add_development_dependency 'action_cable_client'
 end

--- a/spec/integration/rails/lifecycle_spec.rb
+++ b/spec/integration/rails/lifecycle_spec.rb
@@ -1,8 +1,12 @@
 require 'webmock/rspec'
 
+# Old, but still works.
+require 'action_cable_client'
+require 'eventmachine'
 require 'spec_helper'
 require 'zlib'
 require 'stringio'
+require 'securerandom'
 require_relative '../../rails/app'
 
 ScoutApm::Logging::Loggers::FileLogger.class_exec do
@@ -44,6 +48,27 @@ describe ScoutApm::Logging do
     # Call the app to generate the logs
     `curl localhost:9292`
 
+    channel_client = fork do
+      url = 'ws://localhost:9292/cable'
+      channel_name = 'TestChannel'
+      # Loops.
+      EventMachine.run do
+        client = ActionCableClient.new(url, channel_name)
+        # called whenever a welcome message is received from the server
+        client.connected { puts 'successfully connected.' }
+
+        client.subscribed do
+          puts 'client subscribed to the channel.'
+          client.perform('ding', { message: 'hello from client' })
+        end
+
+        # called whenever a message is received from the server
+        client.received do |message|
+          puts message
+        end
+      end
+    end
+
     sleep 5
 
     proxy_dir = context.config.value('logs_proxy_log_dir')
@@ -84,8 +109,17 @@ describe ScoutApm::Logging do
     expect(local_messages.count('Error level log')).to eq(1)
     expect(local_messages.count('Fatal level log')).to eq(1)
 
+    # Verify we recorded server ActionCable messages
+    expect(receiver_contents.count { |msg| msg.include?('ActionCable Connected:') }).to eq(1)
+    expect(receiver_contents.count('Subscribed to test_channel')).to eq(1)
+    expect(receiver_contents.count { |msg| msg.include?('Ding received with data: {"message"') }).to eq(1)
+    expect(local_messages.count { |msg| msg.include?('ActionCable Connected:') }).to eq(1)
+    expect(local_messages.count('Subscribed to test_channel')).to eq(1)
+    expect(local_messages.count { |msg| msg.include?('Ding received with data: {"message"') }).to eq(1)
+
     # Kill the rails process. We use kill as using any other signal throws a long log line.
     Process.kill('KILL', rails_pid)
+    Process.kill('KILL', channel_client)
   end
 
   private


### PR DESCRIPTION
Adds a minimalistic setup of ActionCable for testing.

Is a mix of:
https://github.com/rails/rails/blob/82e9029bbf63a33b69f007927979c5564a6afe9e/actioncable/test/client_test.rb

https://github.com/anycable/simple-cable-app/blob/master/app.rb

As well as adding the following for the client (this is an old library, but still works and is a very lightweight wrapper against websocket-eventmachine):
https://github.com/NullVoxPopuli/action_cable_client/