### PR TITLE
Add Ruby 4.0 to test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.6', '2.7', '3.0', '3.1', '3.2', '3.3', '3.4']
+        ruby: ['2.6', '2.7', '3.0', '3.1', '3.2', '3.3', '3.4', '4.0']
     env:
       DOCKER_RUBY_VERSION: ${{ matrix.ruby }}
       BUNDLE_GEMFILE: gems/rails.gemfile
@@ -21,21 +21,36 @@ jobs:
           echo "LIBRARY_VERSION=$VERSION" >> $GITHUB_ENV
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
-        if: ${{ (env.LIBRARY_VERSION == '1' && !contains(fromJson('["3.4"]'), matrix.ruby)) ||
-                 (env.LIBRARY_VERSION == '2' && !contains(fromJson('["2.6", "2.7", "3.0"]'), matrix.ruby)) }}
+        if: ${{ 
+          (env.LIBRARY_VERSION == '1' && 
+            !startsWith(matrix.ruby, '3.4') && 
+            !startsWith(matrix.ruby, '4.')
+          ) ||
+          (env.LIBRARY_VERSION == '2' && 
+            !startsWith(matrix.ruby, '2.6') && 
+            !startsWith(matrix.ruby, '2.7') && 
+            !startsWith(matrix.ruby, '3.0')
+          )
+        }}
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
       - name: Run RSpec
         run: |
-          if [[ "$LIBRARY_VERSION" == "1" && ("${{ matrix.ruby }}" == "3.4" ) ]]; then
-            echo "Skipping Ruby ${{ matrix.ruby }} for Library v1.x"
+          RUBY="${{ matrix.ruby }}"
+
+          # Library v1: block Ruby >= 3.4 (3.4, 4.x, 5.x, ...)
+          if [[ "$LIBRARY_VERSION" == "1" && ( "$RUBY" == 3.4* || "$RUBY" == 4.* || "$RUBY" == 5.* ) ]]; then
+            echo "Skipping Ruby $RUBY for Library v1.x (>= 3.4 unsupported)"
             exit 0
           fi
-          if [[ "$LIBRARY_VERSION" == "2" && ( "${{ matrix.ruby }}" == "2.6" || "${{ matrix.ruby }}" == "2.7" || "${{ matrix.ruby }}" == "3.0" ) ]]; then
-            echo "Skipping Ruby ${{ matrix.ruby }} for Library v2.x"
+
+          # Library v2: block specific old Rubies
+          if [[ "$LIBRARY_VERSION" == "2" && ( "$RUBY" == 2.6* || "$RUBY" == 2.7* || "$RUBY" == 3.0* ) ]]; then
+            echo "Skipping Ruby $RUBY for Library v2.x"
             exit 0
           fi
+
           bundle exec rake test
 
   rubocop:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,17 +21,7 @@ jobs:
           echo "LIBRARY_VERSION=$VERSION" >> $GITHUB_ENV
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
-        if: ${{ 
-          (env.LIBRARY_VERSION == '1' && 
-            !startsWith(matrix.ruby, '3.4') && 
-            !startsWith(matrix.ruby, '4.')
-          ) ||
-          (env.LIBRARY_VERSION == '2' && 
-            !startsWith(matrix.ruby, '2.6') && 
-            !startsWith(matrix.ruby, '2.7') && 
-            !startsWith(matrix.ruby, '3.0')
-          )
-        }}
+        if: ${{ (env.LIBRARY_VERSION == '1' && !startsWith(matrix.ruby, '3.4') && !startsWith(matrix.ruby, '4.')) || (env.LIBRARY_VERSION == '2' && !startsWith(matrix.ruby, '2.6') && !startsWith(matrix.ruby, '2.7') && !startsWith(matrix.ruby, '3.0')) }}
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ bundle exec rake test file=/path/to/spec/_spec.rb
 
 To run test(s) against a specific Ruby version:
 ```ruby
-DOCKER_RUBY_VERSION=3.4 bundle exec rake test
+DOCKER_RUBY_VERSION=4.0 bundle exec rake test
 ```
 
 ## Local


### PR DESCRIPTION
Updates the test matrix to add 4.0.

For future minor versions, such as 4.x, they just need to be add to the test matrix list.

When a new major version is released, such as 5.0, it will need to be added to in the if statements with a `5.` and `5.*`